### PR TITLE
feat: 私信气泡支持长按选取复制

### DIFF
--- a/app/src/androidTest/java/com/github/zly2006/zhihu/PrivateMessageScreenInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/github/zly2006/zhihu/PrivateMessageScreenInstrumentedTest.kt
@@ -1,0 +1,92 @@
+package com.github.zly2006.zhihu
+
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.longClick
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performTouchInput
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.zly2006.zhihu.data.MobileNotificationAuthor
+import com.github.zly2006.zhihu.data.ZhihuPrivateMessage
+import com.github.zly2006.zhihu.navigation.Notification
+import com.github.zly2006.zhihu.test.MainActivityComposeRule
+import com.github.zly2006.zhihu.test.resetAppPreferences
+import com.github.zly2006.zhihu.test.seedViewModel
+import com.github.zly2006.zhihu.test.setScreenContent
+import com.github.zly2006.zhihu.ui.PRIVATE_MESSAGE_BODY_TAG_PREFIX
+import com.github.zly2006.zhihu.ui.PrivateMessageScreen
+import com.github.zly2006.zhihu.viewmodel.PrivateMessageViewModel
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class PrivateMessageScreenInstrumentedTest {
+    @get:Rule
+    val composeRule: MainActivityComposeRule = createAndroidComposeRule<MainActivity>()
+
+    @Before
+    fun setUp() {
+        composeRule.resetAppPreferences()
+    }
+
+    @Test
+    fun incomingMessageTextCanBeLongPressedToSelect() {
+        val message = ZhihuPrivateMessage(
+            id = "message-copy-1",
+            type = "message",
+            content = "打开这个链接 https://www.zhihu.com/question/123",
+            createdTime = 1_700_000_000,
+            sender = MobileNotificationAuthor(
+                id = PEER_ID,
+                name = "对方",
+                urlToken = PEER_ID,
+            ),
+        )
+        val viewModel = composeRule.seedViewModel(key = "private_message_$PEER_ID") {
+            PrivateMessageViewModel(PEER_ID)
+        }
+        composeRule.activity.runOnUiThread {
+            viewModel.allData.add(message)
+        }
+        composeRule.setScreenContent {
+            PrivateMessageScreen(
+                Notification.Message(
+                    peerId = PEER_ID,
+                    name = "对方",
+                ),
+            )
+        }
+
+        val bodyTag = "$PRIVATE_MESSAGE_BODY_TAG_PREFIX${message.stableId}"
+        composeRule.waitUntil("私信正文未出现", timeoutMillis = 5_000) {
+            composeRule.onAllNodesWithTag(bodyTag).fetchSemanticsNodes().isNotEmpty()
+        }
+        composeRule.onNodeWithText("打开这个链接 https://www.zhihu.com/question/123").assertIsDisplayed()
+        composeRule.onNodeWithTag(bodyTag).performTouchInput { longClick() }
+        composeRule.waitUntil("长按后应出现可选中文本", timeoutMillis = 5_000) {
+            val range = composeRule
+                .onNodeWithTag(bodyTag)
+                .fetchSemanticsNode()
+                .config
+                .getOrNull(SemanticsProperties.TextSelectionRange)
+            range != null && range.length > 0
+        }
+        val selectedRange = composeRule
+            .onNodeWithTag(bodyTag)
+            .fetchSemanticsNode()
+            .config
+            .getOrNull(SemanticsProperties.TextSelectionRange)
+        assertTrue(selectedRange != null && selectedRange.length > 0)
+    }
+
+    private companion object {
+        const val PEER_ID = "peer-copy"
+    }
+}

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/PrivateMessageScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/PrivateMessageScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.outlined.Send
@@ -73,6 +74,8 @@ import com.github.zly2006.zhihu.ui.components.ProgressIndicatorFooter
 import com.github.zly2006.zhihu.util.formatRelativeTime
 import com.github.zly2006.zhihu.viewmodel.PrivateMessageViewModel
 import kotlinx.coroutines.launch
+
+const val PRIVATE_MESSAGE_BODY_TAG_PREFIX = "private_message_body_"
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -254,11 +257,15 @@ private fun PrivateMessageBubble(
                     MaterialTheme.colorScheme.primaryContainer
                 },
             ) {
-                Text(
-                    text = displayText,
-                    style = MaterialTheme.typography.bodyLarge,
-                    modifier = Modifier.padding(horizontal = 14.dp, vertical = 10.dp),
-                )
+                SelectionContainer {
+                    Text(
+                        text = displayText,
+                        style = MaterialTheme.typography.bodyLarge,
+                        modifier = Modifier
+                            .padding(horizontal = 14.dp, vertical = 10.dp)
+                            .testTag("$PRIVATE_MESSAGE_BODY_TAG_PREFIX${message.stableId}"),
+                    )
+                }
             }
             Text(
                 text = formatRelativeTime(message.createdTime),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 必填：AI 使用与验证材料

请如实勾选：

- [ ] 未使用 AI 编写、改写或批量生成代码
- [x] 使用了 AI 编写、改写或批量生成代码

如果使用了 AI，本 PR 必须附上以下验证材料，否则不会进入 review：

- [ ] 已上传测试截图
- [ ] 已上传测试录屏

当前 Cloud Agent 环境没有可用 AVD，无法安装 Lite Debug APK 做真实页面截图。已完成 `assembleLiteDebug` 与 `ktlintFormat`。选取行为由 instrumented test 覆盖，完整设备验证交给 GitHub CI。

## 变更说明

Resolves zly2006/zhihu-plus-plus#666

当前主线私信气泡用普通 `Text` 渲染，长按无法选取或复制。已在当前代码独立复现该现象。

唯一改动：给气泡正文包 `SelectionContainer`，支持长按选取复制。正文增加 `private_message_body_<id>` testTag，并用预填 `PrivateMessageViewModel` 的 instrumented test 断言长按后出现 `TextSelectionRange`。

未实现提交者提到的私信内知乎链接识别/跳转。

## 测试与验证

- `./gradlew assembleLiteDebug`
- `./gradlew ktlintFormat`
- 新增 `PrivateMessageScreenInstrumentedTest.incomingMessageTextCanBeLongPressedToSelect`
- 未改气泡布局、时间戳和发送入口

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-352b837c-d520-478f-a39f-58a71585b3ca?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-352b837c-d520-478f-a39f-58a71585b3ca&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

