### PR TITLE
feat: 回答正文图片铺满宽度，长图预览从顶部按宽显示

### DIFF
--- a/app/src/androidTest/java/com/github/zly2006/zhihu/ArticleScreenInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/github/zly2006/zhihu/ArticleScreenInstrumentedTest.kt
@@ -27,8 +27,10 @@ import android.view.MotionEvent
 import androidx.compose.foundation.ComposeFoundationFlags
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.ScrollState
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.selection.LocalTextSelectionColors
@@ -1251,6 +1253,42 @@ class ArticleScreenInstrumentedTest {
             1200.0 / 880.0,
             imageBounds.width.toDouble() / imageBounds.height.toDouble(),
             0.02,
+        )
+    }
+
+    @Test
+    fun markdownImageFillsContentWidth() {
+        composeRule.setScreenContent {
+            Box(
+                modifier = androidx.compose.ui.Modifier
+                    .fillMaxWidth()
+                    .testTag("markdown-image-host"),
+            ) {
+                RenderImage(
+                    data = MarkdownImageData(
+                        url = "https://invalid.invalid/full-width.jpg",
+                        altText = "铺满宽度的图片",
+                        width = 800,
+                        height = 3200,
+                    ),
+                    modifier = androidx.compose.ui.Modifier,
+                )
+            }
+        }
+
+        val hostBounds = composeRule
+            .onNodeWithTag("markdown-image-host")
+            .fetchSemanticsNode()
+            .boundsInRoot
+        val imageBounds = composeRule
+            .onNodeWithContentDescription("铺满宽度的图片")
+            .fetchSemanticsNode()
+            .boundsInRoot
+        assertTrue("Host width must be reserved", hostBounds.width > 0f)
+        assertEquals(
+            hostBounds.width.toDouble(),
+            imageBounds.width.toDouble(),
+            1.0,
         )
     }
 

--- a/shared/src/androidMain/kotlin/com/github/zly2006/zhihu/ui/components/AndroidComponents.kt
+++ b/shared/src/androidMain/kotlin/com/github/zly2006/zhihu/ui/components/AndroidComponents.kt
@@ -30,7 +30,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.LocalContext
 import androidx.core.graphics.drawable.toDrawable
@@ -88,6 +90,10 @@ class OpenImageDialog(
                             contentDescription = null,
                             modifier = Modifier.fillMaxSize(),
                             state = imageState,
+                            // 默认 Fit 会把整张长图塞进视口，宽度被压得很窄。
+                            // 按宽度铺满并从顶部开始，与官方长图预览一致。
+                            contentScale = ContentScale.FillWidth,
+                            alignment = Alignment.TopCenter,
                             onClick = { onClick() },
                             onLongClick = onLongClick,
                         )

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/markdown/RenderMarkdown.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/markdown/RenderMarkdown.kt
@@ -120,8 +120,9 @@ fun RenderImage(
         AsyncImage(
             model = rememberMarkdownImageModel(data.url),
             contentDescription = data.altText,
+            contentScale = ContentScale.FillWidth,
             modifier = modifier
-                .fillMaxWidth(0.8f)
+                .fillMaxWidth()
                 .then(
                     if (imageAspectRatio != null) {
                         Modifier.aspectRatio(imageAspectRatio)

--- a/third_party/markdown/markdown-renderer/src/commonMain/kotlin/com/hrm/markdown/renderer/MarkdownLayouts.kt
+++ b/third_party/markdown/markdown-renderer/src/commonMain/kotlin/com/hrm/markdown/renderer/MarkdownLayouts.kt
@@ -303,7 +303,8 @@ internal fun estimateMarkdownBlockHeightDp(
                 ?.takeIf { it > 0 }
                 ?.let { width -> node.imageHeight?.toFloat()?.div(width) }
                 ?: 0.75f
-            safeWidth * 0.8f * ratio.coerceIn(0.25f, 3f) +
+            // 与正文块图铺满内容区宽度一致。不要再按 0.8 估算，否则 lazy 高度会偏矮、滚动会跳。
+            safeWidth * ratio.coerceIn(0.25f, 3f) +
                 if (node.caption.isBlank()) 0f else lineHeight
         }
         is FencedCodeBlock ->


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 必填：AI 使用与验证材料

请如实勾选：

- [ ] 未使用 AI 编写、改写或批量生成代码
- [x] 使用了 AI 编写、改写或批量生成代码

如果使用了 AI，本 PR 必须附上以下验证材料，否则不会进入 review：

- [ ] 已上传测试截图
- [ ] 已上传测试录屏

当前 Cloud Agent 环境没有可用 AVD，无法安装 Lite Debug APK 做真实页面截图。已完成 `assembleLiteDebug`、`ktlintFormat`，以及正文图占满宽度的离线 instrumented 断言。完整设备验证交给 GitHub CI。

## 变更说明

Resolves zly2006/zhihu-plus-plus#517

当前主线 Compose Markdown 把所有正文块图限制为内容区 80% 宽，长图在回答里显得极窄；Android 预览默认把整图塞进视口，长图会被进一步压窄。提交者不是 `zly2006`，其“长宽比高于某阈值”方案未采信。

唯一改动：正文块图改为铺满内容区宽度，高度估算同步去掉 0.8，预览初始按宽度铺满并从顶部显示。没有引入比例阈值，也没有改 WebView 正文路径。

## 测试与验证

- `./gradlew assembleLiteDebug`
- `./gradlew ktlintFormat`
- `ArticleScreenInstrumentedTest.markdownImageFillsContentWidth` 断言正文图宽度等于宿主内容区宽度

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-352b837c-d520-478f-a39f-58a71585b3ca?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-352b837c-d520-478f-a39f-58a71585b3ca&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

