### PR TITLE
feat: 存档问答支持本地与服务端独立的自定义保存策略

### DIFF
--- a/app/src/androidTest/java/com/github/zly2006/zhihu/SystemAndUpdateSettingsScreenInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/github/zly2006/zhihu/SystemAndUpdateSettingsScreenInstrumentedTest.kt
@@ -35,16 +35,20 @@ import androidx.compose.ui.test.performScrollToNode
 import androidx.compose.ui.test.performTextInput
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.zly2006.zhihu.data.ARCHIVE_SERVER_ENABLED_PREFERENCE_KEY
+import com.github.zly2006.zhihu.data.ARCHIVE_SERVER_SAVE_STRATEGY_PREFERENCE_KEY
 import com.github.zly2006.zhihu.data.ARCHIVE_SERVER_TOKEN_PREFERENCE_KEY
 import com.github.zly2006.zhihu.data.ARCHIVE_SERVER_URL_PREFERENCE_KEY
 import com.github.zly2006.zhihu.data.LOCAL_ARCHIVE_ENABLED_PREFERENCE_KEY
+import com.github.zly2006.zhihu.data.LOCAL_ARCHIVE_SAVE_STRATEGY_PREFERENCE_KEY
 import com.github.zly2006.zhihu.test.MainActivityComposeRule
 import com.github.zly2006.zhihu.test.performVerticalSwipeCycle
 import com.github.zly2006.zhihu.test.resetAppPreferences
 import com.github.zly2006.zhihu.test.setScreenContent
 import com.github.zly2006.zhihu.ui.PREFERENCE_NAME
+import com.github.zly2006.zhihu.ui.subscreens.SYSTEM_SETTINGS_ARCHIVE_SERVER_STRATEGY_TAG
 import com.github.zly2006.zhihu.ui.subscreens.SYSTEM_SETTINGS_ARCHIVE_TOKEN_TAG
 import com.github.zly2006.zhihu.ui.subscreens.SYSTEM_SETTINGS_ARCHIVE_URL_TAG
+import com.github.zly2006.zhihu.ui.subscreens.SYSTEM_SETTINGS_LOCAL_ARCHIVE_STRATEGY_TAG
 import com.github.zly2006.zhihu.ui.subscreens.SYSTEM_SETTINGS_REMINDER_INTERVAL_TAG
 import com.github.zly2006.zhihu.ui.subscreens.SystemAndUpdateSettingsScreen
 import com.github.zly2006.zhihu.updater.SchematicVersion
@@ -243,6 +247,48 @@ class SystemAndUpdateSettingsScreenInstrumentedTest {
         scrollContainer.performScrollToNode(hasText("导入 / 导出本地存档"))
         composeRule.onNodeWithText("导入 / 导出本地存档").assertIsDisplayed()
         assertFalse(preferences.getBoolean(ARCHIVE_SERVER_ENABLED_PREFERENCE_KEY, false))
+    }
+
+    @Test
+    fun localAndServerArchiveStrategiesPersistIndependently() {
+        setUpScreen()
+        val scrollContainer = scrollContainer()
+
+        scrollContainer.performScrollToNode(hasText("启用本地存档"))
+        clickSettingRow("启用本地存档")
+        waitUntilBooleanPreference(LOCAL_ARCHIVE_ENABLED_PREFERENCE_KEY, expected = true)
+
+        scrollContainer.performScrollToNode(hasTestTag(SYSTEM_SETTINGS_LOCAL_ARCHIVE_STRATEGY_TAG))
+        composeRule.onNodeWithText("本地保存策略").assertIsDisplayed()
+        composeRule.onNodeWithTag(SYSTEM_SETTINGS_LOCAL_ARCHIVE_STRATEGY_TAG).performClick()
+        waitUntilDisplayed(hasText("所有点赞的问答"))
+        composeRule.onNode(hasText("所有点赞的问答"), useUnmergedTree = true).performClick()
+        waitUntil(timeoutMillis = 5_000) {
+            preferences.getString(LOCAL_ARCHIVE_SAVE_STRATEGY_PREFERENCE_KEY, "") == "voted"
+        }
+
+        scrollContainer.performScrollToNode(hasText("存档服务器地址"))
+        composeRule.onNodeWithTag(SYSTEM_SETTINGS_ARCHIVE_URL_TAG).performTextInput("http://192.168.0.10:32100")
+        composeRule.onNodeWithTag(SYSTEM_SETTINGS_ARCHIVE_TOKEN_TAG).performTextInput("local-dev-token")
+        waitUntil(timeoutMillis = 5_000) {
+            preferences.getString(ARCHIVE_SERVER_URL_PREFERENCE_KEY, "") == "http://192.168.0.10:32100" &&
+                preferences.getString(ARCHIVE_SERVER_TOKEN_PREFERENCE_KEY, "") == "local-dev-token"
+        }
+        scrollContainer.performScrollToNode(hasText("启用存档服务器"))
+        clickSettingRow("启用存档服务器")
+        waitUntilBooleanPreference(ARCHIVE_SERVER_ENABLED_PREFERENCE_KEY, expected = true)
+
+        scrollContainer.performScrollToNode(hasTestTag(SYSTEM_SETTINGS_ARCHIVE_SERVER_STRATEGY_TAG))
+        composeRule.onNodeWithText("服务器保存策略").assertIsDisplayed()
+        composeRule.onNodeWithTag(SYSTEM_SETTINGS_ARCHIVE_SERVER_STRATEGY_TAG).performClick()
+        waitUntilDisplayed(hasText("所有收藏的问答"))
+        composeRule.onNode(hasText("所有收藏的问答"), useUnmergedTree = true).performClick()
+        waitUntil(timeoutMillis = 5_000) {
+            preferences.getString(ARCHIVE_SERVER_SAVE_STRATEGY_PREFERENCE_KEY, "") == "collected"
+        }
+
+        assertEquals("voted", preferences.getString(LOCAL_ARCHIVE_SAVE_STRATEGY_PREFERENCE_KEY, ""))
+        assertEquals("collected", preferences.getString(ARCHIVE_SERVER_SAVE_STRATEGY_PREFERENCE_KEY, ""))
     }
 
     private fun setUpScreen() = composeRule.setScreenContent {

--- a/docs/ai-ui-design-guide.md
+++ b/docs/ai-ui-design-guide.md
@@ -122,8 +122,10 @@ URL 解析集中在 `resolveContent()`。支持知乎问题、回答、文章、
 | key/store | 入口 | 主要影响 | 注意 |
 | --- | --- | --- | --- |
 | `githubToken` | GitHub Token | 更新检查 API 限速 | 不要打印或提交真实 token |
-| `enableLocalArchive` | 启用本地存档 | 阅读问题/回答/文章后写入本机 SQLite | 默认关闭；不需要服务器，可与存档服务器同时开启 |
-| `enableArchiveServer` | 启用存档服务器 | 阅读问题/回答/文章后提交到自建存档服务 | 默认关闭；需同时配置地址和令牌 |
+| `enableLocalArchive` | 启用本地存档 | 按本地保存策略写入本机 SQLite | 默认关闭；不需要服务器，可与存档服务器同时开启 |
+| `localArchiveSaveStrategy` | 本地保存策略 | `loaded` / `read` / `voted` / `collected` | 默认 `read`；仅本地存档开启时显示；与服务器策略互不影响 |
+| `enableArchiveServer` | 启用存档服务器 | 按服务器保存策略提交到自建存档服务 | 默认关闭；需同时配置地址和令牌 |
+| `archiveServerSaveStrategy` | 服务器保存策略 | `loaded` / `read` / `voted` / `collected` | 默认 `read`；仅存档服务器开启时显示；与本地策略互不影响 |
 | `archiveServerUrl` | 存档服务器地址 | `POST /api/zhihu/items` 的 API 根地址 | 支持 HTTP 局域网地址 |
 | `archiveServerToken` | 存档服务器令牌 | 请求头 `X-Zhihu-Backup-Token` | 不要打印或提交真实 token |
 | `autoCheckUpdates` | 自动检查更新 | 启动后后台检查 | 通过 update runtime 存取 |

--- a/shared/src/androidMain/kotlin/com/github/zly2006/zhihu/viewmodel/AndroidPaginationEnvironment.android.kt
+++ b/shared/src/androidMain/kotlin/com/github/zly2006/zhihu/viewmodel/AndroidPaginationEnvironment.android.kt
@@ -38,17 +38,20 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import com.github.zly2006.zhihu.data.AIGC_MARKING_ENABLED_PREFERENCE_KEY
 import com.github.zly2006.zhihu.data.ARCHIVE_SERVER_ENABLED_PREFERENCE_KEY
+import com.github.zly2006.zhihu.data.ARCHIVE_SERVER_SAVE_STRATEGY_PREFERENCE_KEY
 import com.github.zly2006.zhihu.data.ARCHIVE_SERVER_TOKEN_PREFERENCE_KEY
 import com.github.zly2006.zhihu.data.ARCHIVE_SERVER_URL_PREFERENCE_KEY
 import com.github.zly2006.zhihu.data.AccountData
 import com.github.zly2006.zhihu.data.AigcVoteClient
 import com.github.zly2006.zhihu.data.AigcVoteVoter
 import com.github.zly2006.zhihu.data.ArchiveClient
+import com.github.zly2006.zhihu.data.ArchiveSaveStrategy
 import com.github.zly2006.zhihu.data.DataHolder
 import com.github.zly2006.zhihu.data.Feed
 import com.github.zly2006.zhihu.data.FeedDisplayItem
 import com.github.zly2006.zhihu.data.HistoryStorage
 import com.github.zly2006.zhihu.data.LOCAL_ARCHIVE_ENABLED_PREFERENCE_KEY
+import com.github.zly2006.zhihu.data.LOCAL_ARCHIVE_SAVE_STRATEGY_PREFERENCE_KEY
 import com.github.zly2006.zhihu.data.ZhihuCookieStorage
 import com.github.zly2006.zhihu.data.ZhihuJson.json
 import com.github.zly2006.zhihu.data.createArchiveClient
@@ -268,6 +271,16 @@ open class SharedAndroidPaginationEnvironment(
         if (!settingsStore.getBoolean(LOCAL_ARCHIVE_ENABLED_PREFERENCE_KEY, false)) return null
         return getLocalArchiveDatabase(context).localArchiveDao()
     }
+
+    override fun localArchiveSaveStrategy(): ArchiveSaveStrategy =
+        ArchiveSaveStrategy.fromKey(
+            settingsStore.getString(LOCAL_ARCHIVE_SAVE_STRATEGY_PREFERENCE_KEY, ArchiveSaveStrategy.Default.key),
+        )
+
+    override fun archiveServerSaveStrategy(): ArchiveSaveStrategy =
+        ArchiveSaveStrategy.fromKey(
+            settingsStore.getString(ARCHIVE_SERVER_SAVE_STRATEGY_PREFERENCE_KEY, ArchiveSaveStrategy.Default.key),
+        )
 
     override fun authenticatedCookies(): Map<String, String> {
         val loginForRecommendation = settingsStore.getBoolean("loginForRecommendation", true)

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/data/ArchiveClient.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/data/ArchiveClient.kt
@@ -31,9 +31,41 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 const val LOCAL_ARCHIVE_ENABLED_PREFERENCE_KEY = "enableLocalArchive"
+const val LOCAL_ARCHIVE_SAVE_STRATEGY_PREFERENCE_KEY = "localArchiveSaveStrategy"
 const val ARCHIVE_SERVER_ENABLED_PREFERENCE_KEY = "enableArchiveServer"
+const val ARCHIVE_SERVER_SAVE_STRATEGY_PREFERENCE_KEY = "archiveServerSaveStrategy"
 const val ARCHIVE_SERVER_URL_PREFERENCE_KEY = "archiveServerUrl"
 const val ARCHIVE_SERVER_TOKEN_PREFERENCE_KEY = "archiveServerToken"
+
+enum class ArchiveSaveStrategy(
+    val key: String,
+) {
+    Loaded("loaded"),
+    Read("read"),
+    Voted("voted"),
+    Collected("collected"),
+    ;
+
+    fun shouldPersist(trigger: ArchiveSaveTrigger): Boolean = when (trigger) {
+        ArchiveSaveTrigger.Loaded -> this == Loaded
+        ArchiveSaveTrigger.Read -> this == Read || this == Loaded
+        ArchiveSaveTrigger.Voted -> this == Voted
+        ArchiveSaveTrigger.Collected -> this == Collected
+    }
+
+    companion object {
+        val Default = Read
+
+        fun fromKey(raw: String?): ArchiveSaveStrategy = entries.find { it.key == raw } ?: Default
+    }
+}
+
+enum class ArchiveSaveTrigger {
+    Loaded,
+    Read,
+    Voted,
+    Collected,
+}
 
 private const val ARCHIVE_TOKEN_HEADER = "X-Zhihu-Backup-Token"
 private const val MIN_ARCHIVE_CONTENT_TEXT_LENGTH = 30
@@ -74,6 +106,38 @@ fun createArchiveClient(
     if (trimmed.isBlank()) return null
     val url = if (trimmed.contains("://")) trimmed else "http://$trimmed"
     return ArchiveClient(httpClient, url, token.trim())
+}
+
+fun createArchiveItem(content: DataHolder.Content): ArchiveItem? = when (content) {
+    is DataHolder.Answer -> createArchiveItem(
+        type = "answer",
+        title = content.question.title,
+        contentHtml = content.content,
+        questionId = content.question.id.toString(),
+        answerId = content.id.toString(),
+        authorName = content.author.name,
+        authorUrl = content.author.url,
+        authorUrlToken = content.author.urlToken,
+    )
+    is DataHolder.Article -> createArchiveItem(
+        type = "article",
+        title = content.title,
+        contentHtml = content.content,
+        articleId = content.id.toString(),
+        authorName = content.author.name,
+        authorUrl = content.author.url,
+        authorUrlToken = content.author.urlToken,
+    )
+    is DataHolder.Question -> createArchiveItem(
+        type = "question",
+        title = content.title,
+        contentHtml = content.detail,
+        questionId = content.id.toString(),
+        authorName = content.author.name,
+        authorUrl = content.author.url,
+        authorUrlToken = content.author.urlToken,
+    )
+    else -> null
 }
 
 fun createArchiveItem(

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/navigation/AnswerNavigator.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/navigation/AnswerNavigator.kt
@@ -22,20 +22,27 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import com.github.zly2006.zhihu.data.ArchiveSaveTrigger
 import com.github.zly2006.zhihu.data.DataHolder
 import com.github.zly2006.zhihu.data.Feed
 import com.github.zly2006.zhihu.data.ZhihuJson
+import com.github.zly2006.zhihu.data.createArchiveItem
 import com.github.zly2006.zhihu.data.navDestination
 import com.github.zly2006.zhihu.data.officialBadge
 import com.github.zly2006.zhihu.data.target
 import com.github.zly2006.zhihu.filter.ContentOpenEventSupport
 import com.github.zly2006.zhihu.util.Log
+import com.github.zly2006.zhihu.viewmodel.ArchiveEnvironment
 import com.github.zly2006.zhihu.viewmodel.ArticleViewModel.CachedAnswerContent
 import com.github.zly2006.zhihu.viewmodel.CollectionItem
 import com.github.zly2006.zhihu.viewmodel.ZhihuApiEnvironment
 import com.github.zly2006.zhihu.viewmodel.filter.ContentType
 import com.github.zly2006.zhihu.viewmodel.filter.getContentFilterDatabase
 import com.github.zly2006.zhihu.viewmodel.getOrFetchContentDetail
+import com.github.zly2006.zhihu.viewmodel.persistArchive
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.serialization.json.JsonElement
@@ -184,6 +191,14 @@ abstract class AnswerNavigator(
      */
     open suspend fun prefetchPrevious(currentArticleId: Long) = Unit
 
+    protected fun archiveLoadedAnswer(detail: DataHolder.Answer) {
+        val archiveEnvironment = environment as? ArchiveEnvironment ?: return
+        val item = createArchiveItem(detail) ?: return
+        CoroutineScope(Dispatchers.Default).launch {
+            persistArchive(archiveEnvironment, item, ArchiveSaveTrigger.Loaded)
+        }
+    }
+
     /**
      * 从来源加载上一个回答（非历史），在 [currentAnswerIndex] == 0（即 [goToPrevious] 返回 null）时由
      * navigateToPrevious 调用。
@@ -300,6 +315,7 @@ class QuestionAnswerNavigator(
 
     private suspend fun fetchCached(article: Article): CachedAnswerContent? {
         val detail = environment.getOrFetchContentDetail(article) as? DataHolder.Answer ?: return null
+        archiveLoadedAnswer(detail)
         return CachedAnswerContent(
             article = article,
             title = detail.question.title,
@@ -770,6 +786,7 @@ class PaginationInfoNavigator(
     private suspend fun fetchCached(answerId: Long): CachedAnswerContent? {
         val dest = Article(id = answerId, type = ArticleType.Answer)
         val detail = environment.getOrFetchContentDetail(dest) as? DataHolder.Answer ?: return null
+        archiveLoadedAnswer(detail)
         return CachedAnswerContent(
             article = dest,
             title = detail.question.title,

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/navigation/AnswerNavigator.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/navigation/AnswerNavigator.kt
@@ -191,12 +191,36 @@ abstract class AnswerNavigator(
      */
     open suspend fun prefetchPrevious(currentArticleId: Long) = Unit
 
-    protected fun archiveLoadedAnswer(detail: DataHolder.Answer) {
-        val archiveEnvironment = environment as? ArchiveEnvironment ?: return
-        val item = createArchiveItem(detail) ?: return
-        CoroutineScope(Dispatchers.Default).launch {
-            persistArchive(archiveEnvironment, item, ArchiveSaveTrigger.Loaded)
+    protected suspend fun fetchCachedAnswer(article: Article): CachedAnswerContent? {
+        val detail = environment.getOrFetchContentDetail(article) as? DataHolder.Answer ?: return null
+        val archiveEnvironment = environment as? ArchiveEnvironment
+        val archiveItem = if (archiveEnvironment != null) createArchiveItem(detail) else null
+        if (archiveEnvironment != null && archiveItem != null) {
+            // 存档写入不能占用导航器互斥锁，否则预取会被本地库和网络拖住。
+            CoroutineScope(Dispatchers.Default).launch {
+                persistArchive(archiveEnvironment, archiveItem, ArchiveSaveTrigger.Loaded)
+            }
         }
+        return CachedAnswerContent(
+            article = article,
+            title = detail.question.title,
+            authorName = detail.author.name,
+            authorBio = detail.author.headline,
+            authorAvatarUrl = detail.author.avatarUrl,
+            authorId = detail.author.id,
+            authorUrlToken = detail.author.urlToken,
+            authorBadge = detail.author.badgeV2.officialBadge(),
+            authorIsFollowing = detail.author.isFollowing,
+            authorIsSelf = detail.isMine,
+            content = detail.content,
+            voteUpCount = detail.voteupCount,
+            commentCount = detail.commentCount,
+            createdAt = detail.createdTime,
+            updatedAt = detail.updatedTime,
+            ipInfo = detail.ipInfo,
+            endorsements = detail.endorsementItems,
+            sourceLabel = sourceName,
+        )
     }
 
     /**
@@ -313,31 +337,6 @@ class QuestionAnswerNavigator(
             )
         }
 
-    private suspend fun fetchCached(article: Article): CachedAnswerContent? {
-        val detail = environment.getOrFetchContentDetail(article) as? DataHolder.Answer ?: return null
-        archiveLoadedAnswer(detail)
-        return CachedAnswerContent(
-            article = article,
-            title = detail.question.title,
-            authorName = detail.author.name,
-            authorBio = detail.author.headline,
-            authorAvatarUrl = detail.author.avatarUrl,
-            authorId = detail.author.id,
-            authorUrlToken = detail.author.urlToken,
-            authorBadge = detail.author.badgeV2.officialBadge(),
-            authorIsFollowing = detail.author.isFollowing,
-            authorIsSelf = detail.isMine,
-            content = detail.content,
-            voteUpCount = detail.voteupCount,
-            commentCount = detail.commentCount,
-            createdAt = detail.createdTime,
-            updatedAt = detail.updatedTime,
-            ipInfo = detail.ipInfo,
-            endorsements = detail.endorsementItems,
-            sourceLabel = sourceName,
-        )
-    }
-
     private suspend fun ensureDestinationsLocked(
         currentArticleId: Long,
         minimumCount: Int,
@@ -427,7 +426,7 @@ class QuestionAnswerNavigator(
         }
         val article = previousQueue.removeFirstOrNull() ?: return@withLock null
         val cached = try {
-            fetchCached(article)
+            fetchCachedAnswer(article)
         } catch (e: Exception) {
             Log.w("QuestionAnswerNavigator", "Failed to load previous answer content", e)
             null
@@ -454,7 +453,7 @@ class QuestionAnswerNavigator(
         if (previousAnswerContent != null) return@withLock
         val article = previousQueue.firstOrNull() ?: return@withLock
         try {
-            previousAnswerContent = fetchCached(article)
+            previousAnswerContent = fetchCachedAnswer(article)
         } catch (e: Exception) {
             Log.w("QuestionAnswerNavigator", "Failed to pre-load previous answer content", e)
         }
@@ -466,7 +465,7 @@ class QuestionAnswerNavigator(
         val nextDest = destinations.firstOrNull() ?: return@withLock
         if (nextDest.type != ArticleType.Answer) return@withLock
         try {
-            nextAnswerContent = fetchCached(nextDest)
+            nextAnswerContent = fetchCachedAnswer(nextDest)
         } catch (e: Exception) {
             Log.w("QuestionAnswerNavigator", "Failed to pre-load next answer content", e)
         }
@@ -574,35 +573,12 @@ class CollectionAnswerNavigator(
         }
         val article = previousQueue.removeFirstOrNull() ?: return@withLock null
         val cached = try {
-            val detail = environment.getOrFetchContentDetail(article) as? DataHolder.Answer
-            if (detail != null) {
-                CachedAnswerContent(
-                    article = article,
-                    title = detail.question.title,
-                    authorName = detail.author.name,
-                    authorBio = detail.author.headline,
-                    authorAvatarUrl = detail.author.avatarUrl,
-                    authorId = detail.author.id,
-                    authorUrlToken = detail.author.urlToken,
-                    authorBadge = detail.author.badgeV2.officialBadge(),
-                    authorIsFollowing = detail.author.isFollowing,
-                    authorIsSelf = detail.isMine,
-                    content = detail.content,
-                    voteUpCount = detail.voteupCount,
-                    commentCount = detail.commentCount,
-                    createdAt = detail.createdTime,
-                    updatedAt = detail.updatedTime,
-                    ipInfo = detail.ipInfo,
-                    endorsements = detail.endorsementItems,
-                    sourceLabel = sourceName,
-                )
-            } else {
-                // 加载失败时退回 previousQueue
-                previousQueue.add(0, article)
-                return@withLock null
-            }
+            fetchCachedAnswer(article)
         } catch (e: Exception) {
             Log.w("CollectionAnswerNavigator", "Failed to load previous answer content", e)
+            null
+        }
+        if (cached == null) {
             previousQueue.add(0, article)
             return@withLock null
         }
@@ -615,27 +591,7 @@ class CollectionAnswerNavigator(
         if (previousAnswerContent != null) return@withLock
         val article = previousQueue.firstOrNull() ?: return@withLock
         try {
-            val detail = environment.getOrFetchContentDetail(article) as? DataHolder.Answer ?: return@withLock
-            previousAnswerContent = CachedAnswerContent(
-                article = article,
-                title = detail.question.title,
-                authorName = detail.author.name,
-                authorBio = detail.author.headline,
-                authorAvatarUrl = detail.author.avatarUrl,
-                authorId = detail.author.id,
-                authorUrlToken = detail.author.urlToken,
-                authorBadge = detail.author.badgeV2.officialBadge(),
-                authorIsFollowing = detail.author.isFollowing,
-                authorIsSelf = detail.isMine,
-                content = detail.content,
-                voteUpCount = detail.voteupCount,
-                commentCount = detail.commentCount,
-                createdAt = detail.createdTime,
-                updatedAt = detail.updatedTime,
-                ipInfo = detail.ipInfo,
-                endorsements = detail.endorsementItems,
-                sourceLabel = sourceName,
-            )
+            previousAnswerContent = fetchCachedAnswer(article)
         } catch (e: Exception) {
             Log.w("CollectionAnswerNavigator", "Failed to pre-load previous answer content", e)
         }
@@ -649,27 +605,7 @@ class CollectionAnswerNavigator(
             prefetchedArticle = queue.removeFirstOrNull()
         }
         try {
-            val detail = environment.getOrFetchContentDetail(article) as? DataHolder.Answer ?: return@withLock
-            nextAnswerContent = CachedAnswerContent(
-                article = article,
-                title = detail.question.title,
-                authorName = detail.author.name,
-                authorBio = detail.author.headline,
-                authorAvatarUrl = detail.author.avatarUrl,
-                authorId = detail.author.id,
-                authorUrlToken = detail.author.urlToken,
-                authorBadge = detail.author.badgeV2.officialBadge(),
-                authorIsFollowing = detail.author.isFollowing,
-                authorIsSelf = detail.isMine,
-                content = detail.content,
-                voteUpCount = detail.voteupCount,
-                commentCount = detail.commentCount,
-                createdAt = detail.createdTime,
-                updatedAt = detail.updatedTime,
-                ipInfo = detail.ipInfo,
-                endorsements = detail.endorsementItems,
-                sourceLabel = sourceName,
-            )
+            nextAnswerContent = fetchCachedAnswer(article)
         } catch (e: Exception) {
             Log.w("CollectionAnswerNavigator", "Failed to pre-load next answer content", e)
         }
@@ -783,32 +719,6 @@ class PaginationInfoNavigator(
         }
     }
 
-    private suspend fun fetchCached(answerId: Long): CachedAnswerContent? {
-        val dest = Article(id = answerId, type = ArticleType.Answer)
-        val detail = environment.getOrFetchContentDetail(dest) as? DataHolder.Answer ?: return null
-        archiveLoadedAnswer(detail)
-        return CachedAnswerContent(
-            article = dest,
-            title = detail.question.title,
-            authorName = detail.author.name,
-            authorBio = detail.author.headline,
-            authorAvatarUrl = detail.author.avatarUrl,
-            authorId = detail.author.id,
-            authorUrlToken = detail.author.urlToken,
-            authorBadge = detail.author.badgeV2.officialBadge(),
-            authorIsFollowing = detail.author.isFollowing,
-            authorIsSelf = detail.isMine,
-            content = detail.content,
-            voteUpCount = detail.voteupCount,
-            commentCount = detail.commentCount,
-            createdAt = detail.createdTime,
-            updatedAt = detail.updatedTime,
-            ipInfo = detail.ipInfo,
-            endorsements = detail.endorsementItems,
-            sourceLabel = sourceName,
-        )
-    }
-
     override suspend fun loadPrevious(): CachedAnswerContent? = nextQueueMutex.withLock {
         // 如果已预取，直接消费
         val prefetched = previousAnswerContent
@@ -819,7 +729,7 @@ class PaginationInfoNavigator(
         }
         val id = prevQueue.removeFirstOrNull() ?: return@withLock null
         val cached = try {
-            fetchCached(id)
+            fetchCachedAnswer(Article(id = id, type = ArticleType.Answer))
         } catch (e: Exception) {
             Log.w("PaginationInfoNavigator", "Failed to load previous answer content", e)
             null
@@ -856,7 +766,7 @@ class PaginationInfoNavigator(
         ensureNextQueueLocked(1)
         val id = nextQueue.firstOrNull() ?: return@withLock
         try {
-            nextAnswerContent = fetchCached(id)
+            nextAnswerContent = fetchCachedAnswer(Article(id = id, type = ArticleType.Answer))
         } catch (e: Exception) {
             Log.w("PaginationInfoNavigator", "Failed to pre-load next answer content", e)
         }
@@ -866,7 +776,7 @@ class PaginationInfoNavigator(
         if (previousAnswerContent != null) return@withLock
         val id = prevQueue.firstOrNull() ?: return@withLock
         try {
-            previousAnswerContent = fetchCached(id)
+            previousAnswerContent = fetchCachedAnswer(Article(id = id, type = ArticleType.Answer))
         } catch (e: Exception) {
             Log.w("PaginationInfoNavigator", "Failed to pre-load previous answer content", e)
         }

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/QuestionScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/QuestionScreen.kt
@@ -99,6 +99,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.fleeksoft.ksoup.Ksoup
+import com.github.zly2006.zhihu.data.ArchiveSaveTrigger
 import com.github.zly2006.zhihu.data.DataHolder
 import com.github.zly2006.zhihu.data.createArchiveItem
 import com.github.zly2006.zhihu.data.decodeQuestionContentDetail
@@ -236,16 +237,12 @@ fun QuestionScreen(
                 ) {
                     launch {
                         withContext(Dispatchers.Default) {
-                            val archiveItem = createArchiveItem(
-                                type = "question",
-                                title = questionData.title,
-                                contentHtml = questionData.detail,
-                                questionId = questionData.id.toString(),
-                                authorName = questionData.author.name,
-                                authorUrl = questionData.author.url,
-                                authorUrlToken = questionData.author.urlToken,
-                            ) ?: return@withContext
-                            persistArchive(paginationEnvironment, archiveItem)
+                            val archiveItem = createArchiveItem(questionData) ?: return@withContext
+                            persistArchive(
+                                paginationEnvironment,
+                                archiveItem,
+                                ArchiveSaveTrigger.Read,
+                            )
                         }
                     }
                 }

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/subscreens/SettingsSearchScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/subscreens/SettingsSearchScreen.kt
@@ -50,9 +50,11 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import com.github.zly2006.zhihu.data.AIGC_MARKING_ENABLED_PREFERENCE_KEY
 import com.github.zly2006.zhihu.data.ARCHIVE_SERVER_ENABLED_PREFERENCE_KEY
+import com.github.zly2006.zhihu.data.ARCHIVE_SERVER_SAVE_STRATEGY_PREFERENCE_KEY
 import com.github.zly2006.zhihu.data.ARCHIVE_SERVER_TOKEN_PREFERENCE_KEY
 import com.github.zly2006.zhihu.data.ARCHIVE_SERVER_URL_PREFERENCE_KEY
 import com.github.zly2006.zhihu.data.LOCAL_ARCHIVE_ENABLED_PREFERENCE_KEY
+import com.github.zly2006.zhihu.data.LOCAL_ARCHIVE_SAVE_STRATEGY_PREFERENCE_KEY
 import com.github.zly2006.zhihu.navigation.Account
 import com.github.zly2006.zhihu.navigation.LocalNavigator
 import com.github.zly2006.zhihu.navigation.NavDestination
@@ -243,9 +245,11 @@ private val settingsSearchEntries = buildList {
     add(systemEntry("system.checkNightlyUpdates", "检查 Nightly 版本更新", "检查每日构建版本。", "checkNightlyUpdates", listOf("每日构建")))
     add(systemEntry("system.allowTelemetry", "允许发送遥测统计数据", "控制匿名使用统计，默认关闭。", "allowTelemetry", listOf("统计", "隐私", "数据收集", "使用数据")))
     add(systemEntry("system.aigcMarking", "启用 AIGC 标记", "开启后可查看其他用户对内容是否疑似 AIGC 的标记。", AIGC_MARKING_ENABLED_PREFERENCE_KEY, listOf("AI", "AIGC")))
-    add(systemEntry("system.localArchive", "启用本地存档", "把阅读过的问题、回答和文章写入本机 SQLite，不需要服务器。", LOCAL_ARCHIVE_ENABLED_PREFERENCE_KEY, listOf("本地备份", "sqlite", "离线存档")))
+    add(systemEntry("system.localArchive", "启用本地存档", "按自定义策略把问答写入本机 SQLite，不需要服务器。", LOCAL_ARCHIVE_ENABLED_PREFERENCE_KEY, listOf("本地备份", "sqlite", "离线存档")))
+    add(systemEntry("system.localArchiveStrategy", "本地保存策略", "加载会保存预取到的问答，阅读只保存打开过的问答，点赞或收藏只在对应操作成功后保存。与服务器策略互不影响。", LOCAL_ARCHIVE_SAVE_STRATEGY_PREFERENCE_KEY, listOf("存档策略", "加载", "阅读", "点赞", "收藏")))
     add(systemEntry("system.localArchiveImportExport", "导入 / 导出本地存档", "把本机存档导出为 JSON，或从 JSON 导入并按链接去重。", "localArchiveImportExport", listOf("导入存档", "导出存档")))
-    add(systemEntry("system.archiveServer", "启用存档服务器", "把阅读过的问题、回答和文章提交到自建存档服务器。", ARCHIVE_SERVER_ENABLED_PREFERENCE_KEY, listOf("备份", "存档", "archive")))
+    add(systemEntry("system.archiveServer", "启用存档服务器", "按自定义策略把问答提交到自建存档服务器。", ARCHIVE_SERVER_ENABLED_PREFERENCE_KEY, listOf("备份", "存档", "archive")))
+    add(systemEntry("system.archiveServerStrategy", "服务器保存策略", "加载会保存预取到的问答，阅读只保存打开过的问答，点赞或收藏只在对应操作成功后保存。与本地策略互不影响。", ARCHIVE_SERVER_SAVE_STRATEGY_PREFERENCE_KEY, listOf("服务器策略", "加载", "阅读", "点赞", "收藏")))
     add(systemEntry("system.archiveServerUrl", "存档服务器地址", "配置存档服务器的 API 地址。", ARCHIVE_SERVER_URL_PREFERENCE_KEY, listOf("备份地址", "存档地址")))
     add(systemEntry("system.archiveServerToken", "存档服务器令牌", "配置存档服务器的访问令牌。", ARCHIVE_SERVER_TOKEN_PREFERENCE_KEY, listOf("备份令牌", "存档令牌")))
     add(systemEntry("system.reminder", "防沉迷提醒", "设置连续使用提醒的间隔。", CONTINUOUS_USAGE_REMINDER_INTERVAL_MINUTES_KEY, listOf("连续使用", "休息提醒")))

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/subscreens/SystemAndUpdateSettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/subscreens/SystemAndUpdateSettingsScreen.kt
@@ -75,9 +75,12 @@ import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import com.github.zly2006.zhihu.data.AIGC_MARKING_ENABLED_PREFERENCE_KEY
 import com.github.zly2006.zhihu.data.ARCHIVE_SERVER_ENABLED_PREFERENCE_KEY
+import com.github.zly2006.zhihu.data.ARCHIVE_SERVER_SAVE_STRATEGY_PREFERENCE_KEY
 import com.github.zly2006.zhihu.data.ARCHIVE_SERVER_TOKEN_PREFERENCE_KEY
 import com.github.zly2006.zhihu.data.ARCHIVE_SERVER_URL_PREFERENCE_KEY
+import com.github.zly2006.zhihu.data.ArchiveSaveStrategy
 import com.github.zly2006.zhihu.data.LOCAL_ARCHIVE_ENABLED_PREFERENCE_KEY
+import com.github.zly2006.zhihu.data.LOCAL_ARCHIVE_SAVE_STRATEGY_PREFERENCE_KEY
 import com.github.zly2006.zhihu.navigation.LocalNavigator
 import com.github.zly2006.zhihu.platform.rememberExternalUrlOpener
 import com.github.zly2006.zhihu.platform.rememberSettingsStore
@@ -103,9 +106,11 @@ import zhihu.shared.generated.resources.ic_telegram_24dp
 internal const val CONTINUOUS_USAGE_REMINDER_INTERVAL_MINUTES_KEY = "continuousUsageReminderIntervalMinutes"
 const val SYSTEM_SETTINGS_AIGC_MARKING_TAG = "system_settings_aigc_marking"
 const val SYSTEM_SETTINGS_LOCAL_ARCHIVE_ENABLED_TAG = "system_settings_local_archive_enabled"
+const val SYSTEM_SETTINGS_LOCAL_ARCHIVE_STRATEGY_TAG = "system_settings_local_archive_strategy"
 const val SYSTEM_SETTINGS_LOCAL_ARCHIVE_IMPORT_TAG = "system_settings_local_archive_import"
 const val SYSTEM_SETTINGS_LOCAL_ARCHIVE_EXPORT_TAG = "system_settings_local_archive_export"
 const val SYSTEM_SETTINGS_ARCHIVE_ENABLED_TAG = "system_settings_archive_enabled"
+const val SYSTEM_SETTINGS_ARCHIVE_SERVER_STRATEGY_TAG = "system_settings_archive_server_strategy"
 const val SYSTEM_SETTINGS_ARCHIVE_URL_TAG = "system_settings_archive_url"
 const val SYSTEM_SETTINGS_ARCHIVE_TOKEN_TAG = "system_settings_archive_token"
 const val SYSTEM_SETTINGS_ARCHIVE_TEST_TAG = "system_settings_archive_test"
@@ -466,7 +471,7 @@ fun SystemAndUpdateSettingsScreen(
                     modifier = Modifier.testTag(SYSTEM_SETTINGS_LOCAL_ARCHIVE_ENABLED_TAG),
                     title = { Text("启用本地存档") },
                     description = {
-                        Text("开启后，阅读问题、回答和文章时会写入本机 SQLite。不需要服务器，也可以和存档服务器同时开启。默认关闭。")
+                        Text("开启后按下方保存策略写入本机 SQLite。不需要服务器，也可以和存档服务器同时开启。默认关闭。")
                     },
                     checked = localArchiveEnabled,
                     onCheckedChange = {
@@ -476,6 +481,31 @@ fun SystemAndUpdateSettingsScreen(
                     settingKey = LOCAL_ARCHIVE_ENABLED_PREFERENCE_KEY,
                     highlightedKey = highlightedSetting,
                 )
+
+                if (localArchiveEnabled) {
+                    var localArchiveStrategy by remember {
+                        mutableStateOf(
+                            ArchiveSaveStrategy.fromKey(
+                                settings.getString(
+                                    LOCAL_ARCHIVE_SAVE_STRATEGY_PREFERENCE_KEY,
+                                    ArchiveSaveStrategy.Default.key,
+                                ),
+                            ),
+                        )
+                    }
+                    ArchiveSaveStrategySetting(
+                        title = "本地保存策略",
+                        description = "加载会保存预取到的问答，阅读只保存打开过的问答，点赞或收藏只在对应操作成功后保存。与服务器策略互不影响。",
+                        settingKey = LOCAL_ARCHIVE_SAVE_STRATEGY_PREFERENCE_KEY,
+                        testTag = SYSTEM_SETTINGS_LOCAL_ARCHIVE_STRATEGY_TAG,
+                        highlightedKey = highlightedSetting,
+                        value = localArchiveStrategy,
+                        onValueChange = {
+                            localArchiveStrategy = it
+                            settings.putString(LOCAL_ARCHIVE_SAVE_STRATEGY_PREFERENCE_KEY, it.key)
+                        },
+                    )
+                }
 
                 SettingItem(
                     title = { Text("导入 / 导出本地存档") },
@@ -535,9 +565,9 @@ fun SystemAndUpdateSettingsScreen(
                     description = {
                         Text(
                             if (archiveConfigured) {
-                                "开启后，阅读问题、回答和文章时会把正文提交到你配置的存档服务器。默认关闭。"
+                                "开启后按下方保存策略把正文提交到你配置的存档服务器。默认关闭。"
                             } else {
-                                "请先填写服务器地址和令牌，再开启。开启后阅读问题、回答和文章时会自动提交正文。"
+                                "请先填写服务器地址和令牌，再开启。开启后按保存策略自动提交正文。"
                             },
                         )
                     },
@@ -547,6 +577,31 @@ fun SystemAndUpdateSettingsScreen(
                     settingKey = ARCHIVE_SERVER_ENABLED_PREFERENCE_KEY,
                     highlightedKey = highlightedSetting,
                 )
+
+                if (archiveEnabled) {
+                    var archiveServerStrategy by remember {
+                        mutableStateOf(
+                            ArchiveSaveStrategy.fromKey(
+                                settings.getString(
+                                    ARCHIVE_SERVER_SAVE_STRATEGY_PREFERENCE_KEY,
+                                    ArchiveSaveStrategy.Default.key,
+                                ),
+                            ),
+                        )
+                    }
+                    ArchiveSaveStrategySetting(
+                        title = "服务器保存策略",
+                        description = "加载会保存预取到的问答，阅读只保存打开过的问答，点赞或收藏只在对应操作成功后保存。与本地策略互不影响。",
+                        settingKey = ARCHIVE_SERVER_SAVE_STRATEGY_PREFERENCE_KEY,
+                        testTag = SYSTEM_SETTINGS_ARCHIVE_SERVER_STRATEGY_TAG,
+                        highlightedKey = highlightedSetting,
+                        value = archiveServerStrategy,
+                        onValueChange = {
+                            archiveServerStrategy = it
+                            settings.putString(ARCHIVE_SERVER_SAVE_STRATEGY_PREFERENCE_KEY, it.key)
+                        },
+                    )
+                }
 
                 SettingItem(
                     title = { Text("存档服务器地址") },
@@ -795,4 +850,66 @@ fun SystemAndUpdateSettingsScreen(
             }
         }
     }
+}
+
+private val archiveSaveStrategyOptions = listOf(
+    ArchiveSaveStrategy.Loaded to "所有加载的问答",
+    ArchiveSaveStrategy.Read to "所有阅读的问答",
+    ArchiveSaveStrategy.Voted to "所有点赞的问答",
+    ArchiveSaveStrategy.Collected to "所有收藏的问答",
+)
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ArchiveSaveStrategySetting(
+    title: String,
+    description: String,
+    settingKey: String,
+    testTag: String,
+    highlightedKey: String,
+    value: ArchiveSaveStrategy,
+    onValueChange: (ArchiveSaveStrategy) -> Unit,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    SettingItem(
+        title = { Text(title) },
+        description = { Text(description) },
+        settingKey = settingKey,
+        highlightedKey = highlightedKey,
+        endAction = {
+            ExposedDropdownMenuBox(
+                expanded = expanded,
+                onExpandedChange = { expanded = it },
+            ) {
+                OutlinedTextField(
+                    value = archiveSaveStrategyOptions.find { it.first == value }?.second
+                        ?: "所有阅读的问答",
+                    onValueChange = {},
+                    readOnly = true,
+                    trailingIcon = {
+                        ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded)
+                    },
+                    modifier = Modifier
+                        .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable)
+                        .width(180.dp)
+                        .testTag(testTag),
+                    colors = ExposedDropdownMenuDefaults.outlinedTextFieldColors(),
+                )
+                ExposedDropdownMenu(
+                    expanded = expanded,
+                    onDismissRequest = { expanded = false },
+                ) {
+                    archiveSaveStrategyOptions.forEach { (strategy, label) ->
+                        DropdownMenuItem(
+                            text = { Text(label) },
+                            onClick = {
+                                onValueChange(strategy)
+                                expanded = false
+                            },
+                        )
+                    }
+                }
+            }
+        },
+    )
 }

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/ArticleViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/ArticleViewModel.kt
@@ -728,7 +728,14 @@ class ArticleViewModel(
         environment: ArchiveEnvironment,
         trigger: ArchiveSaveTrigger,
     ) {
-        val item = createArchiveItem(exportSourceContent ?: return) ?: return
+        val source = exportSourceContent ?: return
+        val matchesCurrent = when (source) {
+            is DataHolder.Answer -> article.type == ArticleType.Answer && source.id == article.id
+            is DataHolder.Article -> article.type == ArticleType.Article && source.id == article.id
+            else -> false
+        }
+        if (!matchesCurrent) return
+        val item = createArchiveItem(source) ?: return
         viewModelScope.launch(Dispatchers.Default) {
             persistArchive(environment, item, trigger)
         }

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/ArticleViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/ArticleViewModel.kt
@@ -30,6 +30,7 @@ import com.github.zly2006.zhihu.data.AigcVoteFlagSubmission
 import com.github.zly2006.zhihu.data.AigcVoteNamedVoter
 import com.github.zly2006.zhihu.data.AigcVoteReadEvent
 import com.github.zly2006.zhihu.data.AigcVoteReadEvidence
+import com.github.zly2006.zhihu.data.ArchiveSaveTrigger
 import com.github.zly2006.zhihu.data.Collection
 import com.github.zly2006.zhihu.data.CollectionResponse
 import com.github.zly2006.zhihu.data.DataHolder
@@ -308,7 +309,7 @@ class ArticleViewModel(
                                 ),
                             )
                             environment.recordOpenEvent(article, answer.question.id)
-                            archiveLoadedContent(environment)
+                            archiveCurrentContent(environment, ArchiveSaveTrigger.Read)
                             withContext(Dispatchers.Main.immediate) {
                                 // 设置问题回答导航器（如果当前不是收藏夹导航器）
                                 if (sharedData?.navigator !is CollectionAnswerNavigator) {
@@ -388,7 +389,7 @@ class ArticleViewModel(
                                 ),
                             )
                             environment.recordOpenEvent(this@ArticleViewModel.article, null)
-                            archiveLoadedContent(environment)
+                            archiveCurrentContent(environment, ArchiveSaveTrigger.Read)
                         } else {
                             content = "<h1>你似乎来到了没有知识存在的荒原</h1>"
                             Log.e("ArticleViewModel", "Article not found")
@@ -420,6 +421,9 @@ class ArticleViewModel(
 
                 if (response.status.isSuccess()) {
                     loadCollections(environment)
+                    if (!remove && environment is ArchiveEnvironment) {
+                        archiveCurrentContent(environment, ArchiveSaveTrigger.Collected)
+                    }
                     userMessages.showShortMessage(if (remove) "取消收藏成功" else "收藏成功")
                 } else {
                     userMessages.showShortMessage("收藏操作失败")
@@ -657,6 +661,9 @@ class ArticleViewModel(
                 voteUpState = newState
                 voteUpCount = response["voteup_count"]!!.jsonPrimitive.int
                 votersTotal = voteUpCount
+                if (newState == VoteUpState.Up && environment is ArchiveEnvironment) {
+                    archiveCurrentContent(environment, ArchiveSaveTrigger.Voted)
+                }
                 if (article.type == ArticleType.Answer) {
                     loadAnswerRelationshipEndorsement(environment)
                     loadMoreVoters(environment, reset = true)
@@ -717,32 +724,13 @@ class ArticleViewModel(
         }
     }
 
-    private fun archiveLoadedContent(environment: ArchiveEnvironment) {
-        if (environment.localArchiveDao() == null && environment.archiveClient() == null) return
-        val item = when (val source = exportSourceContent) {
-            is DataHolder.Answer -> createArchiveItem(
-                type = "answer",
-                title = source.question.title,
-                contentHtml = source.content,
-                questionId = source.question.id.toString(),
-                answerId = source.id.toString(),
-                authorName = source.author.name,
-                authorUrl = source.author.url,
-                authorUrlToken = source.author.urlToken,
-            )
-            is DataHolder.Article -> createArchiveItem(
-                type = "article",
-                title = source.title,
-                contentHtml = source.content,
-                articleId = source.id.toString(),
-                authorName = source.author.name,
-                authorUrl = source.author.url,
-                authorUrlToken = source.author.urlToken,
-            )
-            else -> null
-        } ?: return
+    private fun archiveCurrentContent(
+        environment: ArchiveEnvironment,
+        trigger: ArchiveSaveTrigger,
+    ) {
+        val item = createArchiveItem(exportSourceContent ?: return) ?: return
         viewModelScope.launch(Dispatchers.Default) {
-            persistArchive(environment, item)
+            persistArchive(environment, item, trigger)
         }
     }
 

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/PaginationViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/PaginationViewModel.kt
@@ -29,6 +29,8 @@ import com.github.zly2006.zhihu.data.AigcVoteClient
 import com.github.zly2006.zhihu.data.AigcVoteVoter
 import com.github.zly2006.zhihu.data.ArchiveClient
 import com.github.zly2006.zhihu.data.ArchiveItem
+import com.github.zly2006.zhihu.data.ArchiveSaveStrategy
+import com.github.zly2006.zhihu.data.ArchiveSaveTrigger
 import com.github.zly2006.zhihu.data.ContentDetailCache
 import com.github.zly2006.zhihu.data.DataHolder
 import com.github.zly2006.zhihu.data.Feed
@@ -462,24 +464,33 @@ interface ArchiveEnvironment {
     ): ArchiveClient? = null
 
     fun localArchiveDao(): LocalArchiveDao? = null
+
+    fun localArchiveSaveStrategy(): ArchiveSaveStrategy = ArchiveSaveStrategy.Default
+
+    fun archiveServerSaveStrategy(): ArchiveSaveStrategy = ArchiveSaveStrategy.Default
 }
 
 suspend fun persistArchive(
     environment: ArchiveEnvironment,
     item: ArchiveItem,
+    trigger: ArchiveSaveTrigger = ArchiveSaveTrigger.Read,
 ) {
-    environment.localArchiveDao()?.let { dao ->
-        runCatching {
-            dao.upsertPreservingCreatedAt(item.toLocalArchiveRecord())
-        }.onFailure { error ->
-            if (error is CancellationException) throw error
-            Log.w("Archive", "写入本地存档失败", error)
+    if (environment.localArchiveSaveStrategy().shouldPersist(trigger)) {
+        environment.localArchiveDao()?.let { dao ->
+            runCatching {
+                dao.upsertPreservingCreatedAt(item.toLocalArchiveRecord())
+            }.onFailure { error ->
+                if (error is CancellationException) throw error
+                Log.w("Archive", "写入本地存档失败", error)
+            }
         }
     }
-    environment.archiveClient()?.let { client ->
-        runCatching { client.saveItem(item) }.onFailure { error ->
-            if (error is CancellationException) throw error
-            Log.w("Archive", "提交存档失败", error)
+    if (environment.archiveServerSaveStrategy().shouldPersist(trigger)) {
+        environment.archiveClient()?.let { client ->
+            runCatching { client.saveItem(item) }.onFailure { error ->
+                if (error is CancellationException) throw error
+                Log.w("Archive", "提交存档失败", error)
+            }
         }
     }
 }

--- a/shared/src/commonTest/kotlin/com/github/zly2006/zhihu/data/ArchiveSaveStrategyTest.kt
+++ b/shared/src/commonTest/kotlin/com/github/zly2006/zhihu/data/ArchiveSaveStrategyTest.kt
@@ -1,0 +1,46 @@
+package com.github.zly2006.zhihu.data
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ArchiveSaveStrategyTest {
+    @Test
+    fun fromKeyFallsBackToRead() {
+        assertEquals(ArchiveSaveStrategy.Read, ArchiveSaveStrategy.fromKey(null))
+        assertEquals(ArchiveSaveStrategy.Read, ArchiveSaveStrategy.fromKey(""))
+        assertEquals(ArchiveSaveStrategy.Read, ArchiveSaveStrategy.fromKey("unknown"))
+        assertEquals(ArchiveSaveStrategy.Loaded, ArchiveSaveStrategy.fromKey("loaded"))
+        assertEquals(ArchiveSaveStrategy.Voted, ArchiveSaveStrategy.fromKey("voted"))
+        assertEquals(ArchiveSaveStrategy.Collected, ArchiveSaveStrategy.fromKey("collected"))
+    }
+
+    @Test
+    fun loadedIncludesReadButNotVoteOrCollect() {
+        val strategy = ArchiveSaveStrategy.Loaded
+        assertTrue(strategy.shouldPersist(ArchiveSaveTrigger.Loaded))
+        assertTrue(strategy.shouldPersist(ArchiveSaveTrigger.Read))
+        assertFalse(strategy.shouldPersist(ArchiveSaveTrigger.Voted))
+        assertFalse(strategy.shouldPersist(ArchiveSaveTrigger.Collected))
+    }
+
+    @Test
+    fun readDoesNotIncludePrefetchLoaded() {
+        val strategy = ArchiveSaveStrategy.Read
+        assertFalse(strategy.shouldPersist(ArchiveSaveTrigger.Loaded))
+        assertTrue(strategy.shouldPersist(ArchiveSaveTrigger.Read))
+        assertFalse(strategy.shouldPersist(ArchiveSaveTrigger.Voted))
+        assertFalse(strategy.shouldPersist(ArchiveSaveTrigger.Collected))
+    }
+
+    @Test
+    fun votedAndCollectedAreExclusive() {
+        assertTrue(ArchiveSaveStrategy.Voted.shouldPersist(ArchiveSaveTrigger.Voted))
+        assertFalse(ArchiveSaveStrategy.Voted.shouldPersist(ArchiveSaveTrigger.Collected))
+        assertFalse(ArchiveSaveStrategy.Voted.shouldPersist(ArchiveSaveTrigger.Read))
+        assertTrue(ArchiveSaveStrategy.Collected.shouldPersist(ArchiveSaveTrigger.Collected))
+        assertFalse(ArchiveSaveStrategy.Collected.shouldPersist(ArchiveSaveTrigger.Voted))
+        assertFalse(ArchiveSaveStrategy.Collected.shouldPersist(ArchiveSaveTrigger.Read))
+    }
+}

--- a/shared/src/jvmMain/kotlin/com/github/zly2006/zhihu/viewmodel/PaginationEnvironment.jvm.kt
+++ b/shared/src/jvmMain/kotlin/com/github/zly2006/zhihu/viewmodel/PaginationEnvironment.jvm.kt
@@ -20,13 +20,16 @@ package com.github.zly2006.zhihu.viewmodel
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import com.github.zly2006.zhihu.data.ARCHIVE_SERVER_ENABLED_PREFERENCE_KEY
+import com.github.zly2006.zhihu.data.ARCHIVE_SERVER_SAVE_STRATEGY_PREFERENCE_KEY
 import com.github.zly2006.zhihu.data.ARCHIVE_SERVER_TOKEN_PREFERENCE_KEY
 import com.github.zly2006.zhihu.data.ARCHIVE_SERVER_URL_PREFERENCE_KEY
 import com.github.zly2006.zhihu.data.ArchiveClient
+import com.github.zly2006.zhihu.data.ArchiveSaveStrategy
 import com.github.zly2006.zhihu.data.DataHolder
 import com.github.zly2006.zhihu.data.Feed
 import com.github.zly2006.zhihu.data.FeedDisplayItem
 import com.github.zly2006.zhihu.data.LOCAL_ARCHIVE_ENABLED_PREFERENCE_KEY
+import com.github.zly2006.zhihu.data.LOCAL_ARCHIVE_SAVE_STRATEGY_PREFERENCE_KEY
 import com.github.zly2006.zhihu.data.ZhihuJson.json
 import com.github.zly2006.zhihu.data.createArchiveClient
 import com.github.zly2006.zhihu.data.navDestination
@@ -164,6 +167,16 @@ class DesktopPaginationEnvironment(
         if (!settingsStore.getBoolean(LOCAL_ARCHIVE_ENABLED_PREFERENCE_KEY, false)) return null
         return getLocalArchiveDatabase().localArchiveDao()
     }
+
+    override fun localArchiveSaveStrategy(): ArchiveSaveStrategy =
+        ArchiveSaveStrategy.fromKey(
+            settingsStore.getString(LOCAL_ARCHIVE_SAVE_STRATEGY_PREFERENCE_KEY, ArchiveSaveStrategy.Default.key),
+        )
+
+    override fun archiveServerSaveStrategy(): ArchiveSaveStrategy =
+        ArchiveSaveStrategy.fromKey(
+            settingsStore.getString(ARCHIVE_SERVER_SAVE_STRATEGY_PREFERENCE_KEY, ArchiveSaveStrategy.Default.key),
+        )
 
     override fun xsrfToken(): String = store.load().cookies["_xsrf"] ?: ""
 

--- a/shared/src/jvmTest/kotlin/com/github/zly2006/zhihu/viewmodel/archive/PersistArchiveStrategyTest.kt
+++ b/shared/src/jvmTest/kotlin/com/github/zly2006/zhihu/viewmodel/archive/PersistArchiveStrategyTest.kt
@@ -1,0 +1,122 @@
+package com.github.zly2006.zhihu.viewmodel.archive
+
+import com.github.zly2006.zhihu.data.ArchiveClient
+import com.github.zly2006.zhihu.data.ArchiveSaveStrategy
+import com.github.zly2006.zhihu.data.ArchiveSaveTrigger
+import com.github.zly2006.zhihu.data.ZhihuJson
+import com.github.zly2006.zhihu.data.createArchiveItem
+import com.github.zly2006.zhihu.viewmodel.ArchiveEnvironment
+import com.github.zly2006.zhihu.viewmodel.persistArchive
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.test.runTest
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.io.path.createTempDirectory
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class PersistArchiveStrategyTest {
+    @Test
+    fun localAndServerStrategiesDecideIndependently() = runTest {
+        val database = testDatabase("strategy")
+        val serverPosts = AtomicInteger(0)
+        val environment = StrategyArchiveEnvironment(
+            dao = database.localArchiveDao(),
+            client = recordingClient(serverPosts),
+            localStrategy = ArchiveSaveStrategy.Voted,
+            serverStrategy = ArchiveSaveStrategy.Read,
+        )
+        val item = requireNotNull(
+            createArchiveItem(
+                type = "answer",
+                title = "策略问答",
+                contentHtml = "<p>这是一段足够长的回答正文，用来通过存档服务器要求的三十字以上长度校验。</p>",
+                questionId = "11",
+                answerId = "22",
+            ),
+        )
+
+        persistArchive(environment, item, ArchiveSaveTrigger.Read)
+        assertEquals(0, database.localArchiveDao().count())
+        assertEquals(1, serverPosts.get())
+
+        persistArchive(environment, item, ArchiveSaveTrigger.Voted)
+        assertEquals(1, database.localArchiveDao().count())
+        assertEquals(1, serverPosts.get())
+
+        persistArchive(environment, item, ArchiveSaveTrigger.Collected)
+        assertEquals(1, database.localArchiveDao().count())
+        assertEquals(1, serverPosts.get())
+        database.close()
+    }
+
+    @Test
+    fun loadedStrategyAlsoSavesReadTrigger() = runTest {
+        val database = testDatabase("loaded-read")
+        val serverPosts = AtomicInteger(0)
+        val environment = StrategyArchiveEnvironment(
+            dao = database.localArchiveDao(),
+            client = recordingClient(serverPosts),
+            localStrategy = ArchiveSaveStrategy.Loaded,
+            serverStrategy = ArchiveSaveStrategy.Collected,
+        )
+        val item = requireNotNull(
+            createArchiveItem(
+                type = "article",
+                title = "加载策略",
+                contentHtml = "<p>这是一段足够长的文章正文，用来通过存档服务器要求的三十字以上长度校验。</p>",
+                articleId = "33",
+            ),
+        )
+
+        persistArchive(environment, item, ArchiveSaveTrigger.Read)
+        assertEquals(1, database.localArchiveDao().count())
+        assertEquals(0, serverPosts.get())
+        database.close()
+    }
+
+    private fun recordingClient(serverPosts: AtomicInteger): ArchiveClient = ArchiveClient(
+        httpClient = HttpClient(
+            MockEngine {
+                serverPosts.incrementAndGet()
+                respond(
+                    content = """{"ok":true,"id":1}""",
+                    status = HttpStatusCode.OK,
+                    headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                )
+            },
+        ) {
+            install(ContentNegotiation) {
+                json(ZhihuJson.json)
+            }
+        },
+        baseUrl = "http://127.0.0.1:32100",
+        token = "token",
+    )
+
+    private fun testDatabase(name: String): LocalArchiveDatabase =
+        getLocalArchiveDatabase(
+            createTempDirectory("persist-archive-$name").resolve("local-archive.db").toFile(),
+        )
+}
+
+private class StrategyArchiveEnvironment(
+    private val dao: LocalArchiveDao?,
+    private val client: ArchiveClient?,
+    private val localStrategy: ArchiveSaveStrategy,
+    private val serverStrategy: ArchiveSaveStrategy,
+) : ArchiveEnvironment {
+    override fun archiveClient(): ArchiveClient? = client
+
+    override fun localArchiveDao(): LocalArchiveDao? = dao
+
+    override fun localArchiveSaveStrategy(): ArchiveSaveStrategy = localStrategy
+
+    override fun archiveServerSaveStrategy(): ArchiveSaveStrategy = serverStrategy
+}

--- a/shared/src/jvmTest/kotlin/com/github/zly2006/zhihu/viewmodel/archive/PersistArchiveStrategyTest.kt
+++ b/shared/src/jvmTest/kotlin/com/github/zly2006/zhihu/viewmodel/archive/PersistArchiveStrategyTest.kt
@@ -81,6 +81,32 @@ class PersistArchiveStrategyTest {
         database.close()
     }
 
+    @Test
+    fun loadedTriggerWritesLocalOnlyWhenServerUsesRead() = runTest {
+        val database = testDatabase("loaded-trigger")
+        val serverPosts = AtomicInteger(0)
+        val environment = StrategyArchiveEnvironment(
+            dao = database.localArchiveDao(),
+            client = recordingClient(serverPosts),
+            localStrategy = ArchiveSaveStrategy.Loaded,
+            serverStrategy = ArchiveSaveStrategy.Read,
+        )
+        val item = requireNotNull(
+            createArchiveItem(
+                type = "answer",
+                title = "预取问答",
+                contentHtml = "<p>这是一段足够长的回答正文，用来通过存档服务器要求的三十字以上长度校验。</p>",
+                questionId = "44",
+                answerId = "55",
+            ),
+        )
+
+        persistArchive(environment, item, ArchiveSaveTrigger.Loaded)
+        assertEquals(1, database.localArchiveDao().count())
+        assertEquals(0, serverPosts.get())
+        database.close()
+    }
+
     private fun recordingClient(serverPosts: AtomicInteger): ArchiveClient = ArchiveClient(
         httpClient = HttpClient(
             MockEngine {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 必填：AI 使用与验证材料

请如实勾选：

- [ ] 未使用 AI 编写、改写或批量生成代码
- [x] 使用了 AI 编写、改写或批量生成代码

如果使用了 AI，本 PR 必须附上以下验证材料，否则不会进入 review：

- [ ] 已上传测试截图
- [ ] 已上传测试录屏

当前 Cloud Agent 环境没有可用 AVD，无法安装 Lite Debug APK 做真实页面截图。已完成 `assembleLiteDebug`、`ktlintFormat`，以及策略匹配、本地/服务端独立写入、导航器相关单测。完整设备验证交给 GitHub CI。

## 变更说明

存档问答增加自定义保存策略，本地和服务端相互独立，各自可选：

- 所有加载的问答：打开阅读页和预取到的回答都会保存
- 所有阅读的问答：只保存打开过的问答（默认，保持现有行为）
- 所有点赞的问答：点赞成功后才保存
- 所有收藏的问答：加入收藏夹成功后才保存

没有改导入/导出、服务器地址令牌，也没有让两端共用同一个策略。

自我审计后补了两处契约漏洞：

- 收藏夹导航器预取/加载回答现在也走 Loaded，不再只覆盖问题和分页导航器
- 切到下一篇后，点赞或收藏不会再用上一篇正文落档

## 测试与验证

- `./gradlew assembleLiteDebug`
- `./gradlew ktlintFormat`
- `ArchiveSaveStrategyTest`
- `PersistArchiveStrategyTest`
- `CollectionAnswerNavigatorTest`
- `QuestionAnswerNavigatorTest`
- `SystemAndUpdateSettingsScreenInstrumentedTest.localAndServerArchiveStrategiesPersistIndependently`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-352b837c-d520-478f-a39f-58a71585b3ca?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-352b837c-d520-478f-a39f-58a71585b3ca&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

