### PR TITLE
feat: 增加老年模式，默认跟随系统并可手动开关

### DIFF
--- a/app/src/androidTest/java/com/github/zly2006/zhihu/AppearanceSettingsScreenInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/github/zly2006/zhihu/AppearanceSettingsScreenInstrumentedTest.kt
@@ -111,12 +111,13 @@ class AppearanceSettingsScreenInstrumentedTest {
         waitUntilTagExists(APPEARANCE_SETTINGS_ELDERLY_MODE_TAG)
         scrollUntilTagDisplayed(APPEARANCE_SETTINGS_ELDERLY_MODE_TAG)
         assertFalse(preferences.contains(ELDERLY_MODE_PREFERENCE_KEY))
-        composeRule.onNodeWithTag(APPEARANCE_SETTINGS_ELDERLY_MODE_TAG).performClick()
-        waitUntilBooleanPreference(ELDERLY_MODE_PREFERENCE_KEY, expected = true)
+        val systemEnabled = readSystemElderlyModeEnabled(composeRule.activity.contentResolver)
 
         composeRule.onNodeWithTag(APPEARANCE_SETTINGS_ELDERLY_MODE_TAG).performClick()
-        waitUntilBooleanPreference(ELDERLY_MODE_PREFERENCE_KEY, expected = false)
-        assertFalse(readSystemElderlyModeEnabled(composeRule.activity.contentResolver))
+        waitUntilBooleanPreference(ELDERLY_MODE_PREFERENCE_KEY, expected = !systemEnabled)
+
+        composeRule.onNodeWithTag(APPEARANCE_SETTINGS_ELDERLY_MODE_TAG).performClick()
+        waitUntilBooleanPreference(ELDERLY_MODE_PREFERENCE_KEY, expected = systemEnabled)
     }
 
     @Test

--- a/app/src/androidTest/java/com/github/zly2006/zhihu/AppearanceSettingsScreenInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/github/zly2006/zhihu/AppearanceSettingsScreenInstrumentedTest.kt
@@ -45,6 +45,8 @@ import com.github.zly2006.zhihu.navigation.OnlineHistory
 import com.github.zly2006.zhihu.test.performVerticalSwipeCycle
 import com.github.zly2006.zhihu.test.resetAppPreferences
 import com.github.zly2006.zhihu.test.setScreenContent
+import com.github.zly2006.zhihu.theme.ELDERLY_MODE_PREFERENCE_KEY
+import com.github.zly2006.zhihu.theme.readSystemElderlyModeEnabled
 import com.github.zly2006.zhihu.ui.ANSWER_DOUBLE_TAP_ACTION_PREFERENCE_KEY
 import com.github.zly2006.zhihu.ui.ARTICLE_USE_WEBVIEW_PREFERENCE_KEY
 import com.github.zly2006.zhihu.ui.AnswerDoubleTapAction
@@ -52,6 +54,7 @@ import com.github.zly2006.zhihu.ui.PREFERENCE_NAME
 import com.github.zly2006.zhihu.ui.subscreens.APPEARANCE_SETTINGS_ANSWER_DOUBLE_TAP_TAG
 import com.github.zly2006.zhihu.ui.subscreens.APPEARANCE_SETTINGS_BOTTOM_BAR_SECTION_KEY
 import com.github.zly2006.zhihu.ui.subscreens.APPEARANCE_SETTINGS_COLLECTION_DIRECT_BROWSE_TAG
+import com.github.zly2006.zhihu.ui.subscreens.APPEARANCE_SETTINGS_ELDERLY_MODE_TAG
 import com.github.zly2006.zhihu.ui.subscreens.APPEARANCE_SETTINGS_SCROLL_TAG
 import com.github.zly2006.zhihu.ui.subscreens.APPEARANCE_SETTINGS_START_DESTINATION_TAG
 import com.github.zly2006.zhihu.ui.subscreens.APPEARANCE_SETTINGS_USE_WEBVIEW_TAG
@@ -99,6 +102,21 @@ class AppearanceSettingsScreenInstrumentedTest {
         scrollUntilTagDisplayed(APPEARANCE_SETTINGS_USE_WEBVIEW_TAG)
         composeRule.onNodeWithTag(APPEARANCE_SETTINGS_USE_WEBVIEW_TAG).performClick()
         waitUntilBooleanPreference(ARTICLE_USE_WEBVIEW_PREFERENCE_KEY, expected = false)
+    }
+
+    @Test
+    fun togglingElderlyModePersistsOverride() {
+        setUpScreen(setting = ELDERLY_MODE_PREFERENCE_KEY)
+
+        waitUntilTagExists(APPEARANCE_SETTINGS_ELDERLY_MODE_TAG)
+        scrollUntilTagDisplayed(APPEARANCE_SETTINGS_ELDERLY_MODE_TAG)
+        assertFalse(preferences.contains(ELDERLY_MODE_PREFERENCE_KEY))
+        composeRule.onNodeWithTag(APPEARANCE_SETTINGS_ELDERLY_MODE_TAG).performClick()
+        waitUntilBooleanPreference(ELDERLY_MODE_PREFERENCE_KEY, expected = true)
+
+        composeRule.onNodeWithTag(APPEARANCE_SETTINGS_ELDERLY_MODE_TAG).performClick()
+        waitUntilBooleanPreference(ELDERLY_MODE_PREFERENCE_KEY, expected = false)
+        assertFalse(readSystemElderlyModeEnabled(composeRule.activity.contentResolver))
     }
 
     @Test

--- a/docs/ai-ui-design-guide.md
+++ b/docs/ai-ui-design-guide.md
@@ -65,6 +65,7 @@ URL 解析集中在 `resolveContent()`。支持知乎问题、回答、文章、
 | `useDynamicColor` | Material You 动态取色 | Android 12+ 取系统壁纸色 | 关闭后自定义主题色才明显生效 |
 | `customThemeColor` | 自定义主题色 | Material 3 主色 | 不要和动态取色同时假设生效 |
 | `backgroundColorLight`, `backgroundColorDark` | 自定义背景颜色 | 明暗模式背景 | 按当前明暗模式写入不同 key |
+| `elderlyMode` | 老年模式 | 放大界面 `sp` 文字 | 未手动设置时跟随系统老年/简易/关怀模式；开关可覆盖。查 `ElderlyMode.kt` 与 `ZhihuTheme` |
 | `contentFontSize`, `contentLineHeight`, `contentBlockSpacing` | 字号、行高、段间距 | 正文字号/行高、分段文本样式和 Markdown 正文块间距 | 查 `SegmentedText` 和 Markdown 渲染路径 |
 | `showFeedThumbnail` | Feed 卡片缩略图 | 信息流卡片是否显示图 | 由复用 `FeedCard` 的页面读取 |
 | `showRefreshFab` | 刷新 FAB | 首页/列表可拖动刷新按钮显示 | 123Duo3 总开关会关闭它 |

--- a/shared/src/androidMain/kotlin/com/github/zly2006/zhihu/theme/ElderlyMode.android.kt
+++ b/shared/src/androidMain/kotlin/com/github/zly2006/zhihu/theme/ElderlyMode.android.kt
@@ -1,0 +1,63 @@
+/*
+ * Zhihu++ - Free & Ad-Free Zhihu client for all platforms.
+ * Copyright (C) 2024-2026, zly2006 <i@zly2006.me>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation (version 3 only).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.github.zly2006.zhihu.theme
+
+import android.content.ContentResolver
+import android.provider.Settings
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalContext
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
+
+fun readSystemElderlyModeEnabled(resolver: ContentResolver): Boolean =
+    SYSTEM_ELDERLY_MODE_SETTING_KEYS.any { key ->
+        settingValueEnablesElderlyMode(Settings.System.getString(resolver, key)) ||
+            settingValueEnablesElderlyMode(Settings.Secure.getString(resolver, key)) ||
+            settingValueEnablesElderlyMode(Settings.Global.getString(resolver, key))
+    }
+
+@Composable
+actual fun rememberSystemElderlyModeEnabled(): Boolean {
+    val context = LocalContext.current.applicationContext
+    val configuration = LocalConfiguration.current
+    val lifecycleOwner = LocalLifecycleOwner.current
+    var enabled by remember {
+        mutableStateOf(readSystemElderlyModeEnabled(context.contentResolver))
+    }
+    DisposableEffect(lifecycleOwner, configuration) {
+        fun refresh() {
+            enabled = readSystemElderlyModeEnabled(context.contentResolver)
+        }
+        refresh()
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) {
+                refresh()
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
+    return enabled
+}

--- a/shared/src/androidMain/kotlin/com/github/zly2006/zhihu/theme/ElderlyMode.android.kt
+++ b/shared/src/androidMain/kotlin/com/github/zly2006/zhihu/theme/ElderlyMode.android.kt
@@ -56,6 +56,8 @@ private val SYSTEM_ELDERLY_MODE_SETTING_KEYS = listOf(
 
 fun readSystemElderlyModeEnabled(resolver: ContentResolver): Boolean =
     SYSTEM_ELDERLY_MODE_SETTING_KEYS.any { key ->
+        // 必须用 getString。旧 MIUI isSimpleMode 对缺失的 simple_mode 使用 getInt(..., 1)，
+        // 键不存在时会当成已开启；getString 在键缺失时返回 null，才能保持“未写入即未开启”。
         settingValueEnablesElderlyMode(safeSettingString { Settings.System.getString(resolver, key) }) ||
             settingValueEnablesElderlyMode(safeSettingString { Settings.Secure.getString(resolver, key) }) ||
             settingValueEnablesElderlyMode(safeSettingString { Settings.Global.getString(resolver, key) })

--- a/shared/src/androidMain/kotlin/com/github/zly2006/zhihu/theme/ElderlyMode.android.kt
+++ b/shared/src/androidMain/kotlin/com/github/zly2006/zhihu/theme/ElderlyMode.android.kt
@@ -31,12 +31,37 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 
+/**
+ * 各厂商系统老年/简易/关怀模式使用的 Settings 键。
+ *
+ * AOSP 没有统一老年模式 API，只能读取厂商写入的键；键不存在或读失败时不得当成已开启。
+ */
+private val SYSTEM_ELDERLY_MODE_SETTING_KEYS = listOf(
+    "elderly_mode",
+    "elder_mode",
+    "elderly_care",
+    "hw_elderly_mode",
+    "senior_mode",
+    "care_mode",
+    "easy_mode",
+    "easy_mode_switch",
+    "easy_mode_state",
+    "sem_easy_mode",
+    "simple_mode",
+    "oldman_mode",
+    "oplus_easy_mode",
+    "color_easy_mode",
+    "vivo_easy_mode",
+)
+
 fun readSystemElderlyModeEnabled(resolver: ContentResolver): Boolean =
     SYSTEM_ELDERLY_MODE_SETTING_KEYS.any { key ->
-        settingValueEnablesElderlyMode(Settings.System.getString(resolver, key)) ||
-            settingValueEnablesElderlyMode(Settings.Secure.getString(resolver, key)) ||
-            settingValueEnablesElderlyMode(Settings.Global.getString(resolver, key))
+        settingValueEnablesElderlyMode(safeSettingString { Settings.System.getString(resolver, key) }) ||
+            settingValueEnablesElderlyMode(safeSettingString { Settings.Secure.getString(resolver, key) }) ||
+            settingValueEnablesElderlyMode(safeSettingString { Settings.Global.getString(resolver, key) })
     }
+
+private fun safeSettingString(read: () -> String?): String? = runCatching { read() }.getOrNull()
 
 @Composable
 actual fun rememberSystemElderlyModeEnabled(): Boolean {

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/theme/ElderlyMode.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/theme/ElderlyMode.kt
@@ -56,7 +56,7 @@ fun rememberElderlyModeEnabled(): Boolean {
         }
         onDispose { unregister() }
     }
-    return remember(revision, systemEnabled) {
+    return remember(revision, systemEnabled, settings) {
         settings.getBoolean(ELDERLY_MODE_PREFERENCE_KEY, systemEnabled)
     }
 }

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/theme/ElderlyMode.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/theme/ElderlyMode.kt
@@ -35,38 +35,10 @@ const val ELDERLY_MODE_PREFERENCE_KEY = "elderlyMode"
  */
 const val ELDERLY_MODE_FONT_SCALE = 1.25f
 
-/**
- * 各厂商系统老年/简易/关怀模式使用的 Settings 键。
- *
- * AOSP 没有统一老年模式 API，只能读取厂商写入的键；键不存在时不得当成已开启。
- */
-internal val SYSTEM_ELDERLY_MODE_SETTING_KEYS = listOf(
-    "elderly_mode",
-    "elder_mode",
-    "elderly_care",
-    "hw_elderly_mode",
-    "senior_mode",
-    "care_mode",
-    "easy_mode",
-    "easy_mode_switch",
-    "easy_mode_state",
-    "sem_easy_mode",
-    "simple_mode",
-    "oldman_mode",
-    "oplus_easy_mode",
-    "color_easy_mode",
-    "vivo_easy_mode",
-)
-
-fun settingValueEnablesElderlyMode(raw: String?): Boolean {
+internal fun settingValueEnablesElderlyMode(raw: String?): Boolean {
     val value = raw?.trim()?.lowercase() ?: return false
     return value == "1" || value == "true" || value == "on" || value == "yes"
 }
-
-fun resolveElderlyModeEnabled(
-    stored: Boolean?,
-    systemEnabled: Boolean,
-): Boolean = stored ?: systemEnabled
 
 @Composable
 expect fun rememberSystemElderlyModeEnabled(): Boolean

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/theme/ElderlyMode.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/theme/ElderlyMode.kt
@@ -1,0 +1,90 @@
+/*
+ * Zhihu++ - Free & Ad-Free Zhihu client for all platforms.
+ * Copyright (C) 2024-2026, zly2006 <i@zly2006.me>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation (version 3 only).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.github.zly2006.zhihu.theme
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import com.github.zly2006.zhihu.platform.rememberSettingsStore
+
+const val ELDERLY_MODE_PREFERENCE_KEY = "elderlyMode"
+
+/**
+ * 老年模式开启后的界面文字倍率。
+ *
+ * 只放大 `sp`，不改 `dp` 密度，避免整页布局被二次缩放后裁切或重叠。
+ * 正文仍叠加用户自己的 [com.github.zly2006.zhihu.ui.subscreens.PREF_FONT_SIZE]。
+ */
+const val ELDERLY_MODE_FONT_SCALE = 1.25f
+
+/**
+ * 各厂商系统老年/简易/关怀模式使用的 Settings 键。
+ *
+ * AOSP 没有统一老年模式 API，只能读取厂商写入的键；键不存在时不得当成已开启。
+ */
+internal val SYSTEM_ELDERLY_MODE_SETTING_KEYS = listOf(
+    "elderly_mode",
+    "elder_mode",
+    "elderly_care",
+    "hw_elderly_mode",
+    "senior_mode",
+    "care_mode",
+    "easy_mode",
+    "easy_mode_switch",
+    "easy_mode_state",
+    "sem_easy_mode",
+    "simple_mode",
+    "oldman_mode",
+    "oplus_easy_mode",
+    "color_easy_mode",
+    "vivo_easy_mode",
+)
+
+fun settingValueEnablesElderlyMode(raw: String?): Boolean {
+    val value = raw?.trim()?.lowercase() ?: return false
+    return value == "1" || value == "true" || value == "on" || value == "yes"
+}
+
+fun resolveElderlyModeEnabled(
+    stored: Boolean?,
+    systemEnabled: Boolean,
+): Boolean = stored ?: systemEnabled
+
+@Composable
+expect fun rememberSystemElderlyModeEnabled(): Boolean
+
+@Composable
+fun rememberElderlyModeEnabled(): Boolean {
+    val settings = rememberSettingsStore()
+    val systemEnabled = rememberSystemElderlyModeEnabled()
+    var revision by remember { mutableIntStateOf(0) }
+    DisposableEffect(settings) {
+        val unregister = settings.observeKeyChanges { key ->
+            if (key == ELDERLY_MODE_PREFERENCE_KEY) {
+                revision++
+            }
+        }
+        onDispose { unregister() }
+    }
+    return remember(revision, systemEnabled) {
+        settings.getBoolean(ELDERLY_MODE_PREFERENCE_KEY, systemEnabled)
+    }
+}

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/theme/Theme.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/theme/Theme.kt
@@ -77,6 +77,7 @@ fun ZhihuTheme(
     PlatformSystemBarEffect(darkTheme)
 
     val elderlyModeEnabled = rememberElderlyModeEnabled()
+    // 必须读外层系统 density。若在 Provider 内再读 LocalDensity，重组会把 1.25 叠乘上去。
     val density = LocalDensity.current
     val themedDensity = if (elderlyModeEnabled) {
         Density(

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/theme/Theme.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/theme/Theme.kt
@@ -22,7 +22,10 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Density
 import com.materialkolor.dynamicColorScheme
 
 private val DarkColorScheme = darkColorScheme(
@@ -73,11 +76,24 @@ fun ZhihuTheme(
 
     PlatformSystemBarEffect(darkTheme)
 
-    MaterialTheme(
-        colorScheme = colorScheme,
-        typography = Typography,
-        content = content,
-    )
+    val elderlyModeEnabled = rememberElderlyModeEnabled()
+    val density = LocalDensity.current
+    val themedDensity = if (elderlyModeEnabled) {
+        Density(
+            density = density.density,
+            fontScale = density.fontScale * ELDERLY_MODE_FONT_SCALE,
+        )
+    } else {
+        density
+    }
+
+    CompositionLocalProvider(LocalDensity provides themedDensity) {
+        MaterialTheme(
+            colorScheme = colorScheme,
+            typography = Typography,
+            content = content,
+        )
+    }
 }
 
 @Composable

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/subscreens/AppearanceSettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/subscreens/AppearanceSettingsScreen.kt
@@ -95,8 +95,10 @@ import com.github.zly2006.zhihu.navigation.OnlineHistory
 import com.github.zly2006.zhihu.navigation.TopLevelDestination
 import com.github.zly2006.zhihu.platform.rememberSettingsStore
 import com.github.zly2006.zhihu.platform.rememberUserMessageSink
+import com.github.zly2006.zhihu.theme.ELDERLY_MODE_PREFERENCE_KEY
 import com.github.zly2006.zhihu.theme.ThemeManager
 import com.github.zly2006.zhihu.theme.ThemeMode
+import com.github.zly2006.zhihu.theme.rememberSystemElderlyModeEnabled
 import com.github.zly2006.zhihu.ui.ANSWER_DOUBLE_TAP_ACTION_PREFERENCE_KEY
 import com.github.zly2006.zhihu.ui.ARTICLE_USE_WEBVIEW_PREFERENCE_KEY
 import com.github.zly2006.zhihu.ui.AnswerDoubleTapAction
@@ -129,6 +131,7 @@ const val APPEARANCE_SETTINGS_WEBVIEW_FONT_TAG = "appearanceSettings.webViewFont
 const val APPEARANCE_SETTINGS_WEBVIEW_OPTIONS_TAG = "appearanceSettings.webViewOptions"
 const val APPEARANCE_SETTINGS_BOTTOM_BAR_SECTION_KEY = "appearanceSettings.bottomBarSection"
 const val APPEARANCE_SETTINGS_COLLECTION_DIRECT_BROWSE_TAG = "appearanceSettings.collectionDirectBrowse"
+const val APPEARANCE_SETTINGS_ELDERLY_MODE_TAG = "appearanceSettings.elderlyMode"
 
 const val START_DESTINATION_PREFERENCE_KEY = "startDestination"
 const val BOTTOM_BAR_ITEMS_PREFERENCE_KEY = "bottom_bar_items"
@@ -261,7 +264,7 @@ internal fun shouldShowAccountHistoryShortcut(
 /**
  * 外观与阅读体验设置页。
  *
- * 这里集中管理主题、字号/行高、信息流样式、文章页行为、底部导航栏、分享、搜索和技术性导航开关。页面支持通过 [setting]
+ * 这里集中管理主题、老年模式、字号/行高、信息流样式、文章页行为、底部导航栏、分享、搜索和技术性导航开关。页面支持通过 [setting]
  * 跳入指定设置项并高亮滚动到位，因此新增设置时应提供稳定的 `settingKey`，必要时也补充 test tag。
  *
  * 底部导航栏相关设置会影响 [com.github.zly2006.zhihu.ui.ZhihuMain] 的主壳状态；页面退出时必须通过 [onExit]
@@ -563,6 +566,32 @@ fun AppearanceSettingsScreen(
             SettingItemGroup(
                 title = "阅读",
             ) {
+                val systemElderlyMode = rememberSystemElderlyModeEnabled()
+                var elderlyMode by remember(systemElderlyMode) {
+                    mutableStateOf(settings.getBoolean(ELDERLY_MODE_PREFERENCE_KEY, systemElderlyMode))
+                }
+                SettingItemWithSwitch(
+                    modifier = Modifier.testTag(APPEARANCE_SETTINGS_ELDERLY_MODE_TAG),
+                    title = { Text("老年模式") },
+                    description = {
+                        Text(
+                            if (systemElderlyMode) {
+                                "已跟随系统老年模式默认打开，放大界面文字。也可手动开关。"
+                            } else {
+                                "系统老年模式开启时默认打开，放大界面文字。也可手动开关。"
+                            },
+                        )
+                    },
+                    checked = elderlyMode,
+                    onCheckedChange = {
+                        elderlyMode = it
+                        settings.putBoolean(ELDERLY_MODE_PREFERENCE_KEY, it)
+                    },
+                    settingKey = ELDERLY_MODE_PREFERENCE_KEY,
+                    highlightedKey = settingKey,
+                    bringIntoViewRequester = requesterFor(ELDERLY_MODE_PREFERENCE_KEY),
+                )
+
                 var fontSize by remember { mutableIntStateOf(settings.getInt(PREF_FONT_SIZE, 100)) }
                 SettingItem(
                     title = { Text("字号") },

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/subscreens/AppearanceSettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/subscreens/AppearanceSettingsScreen.kt
@@ -98,7 +98,7 @@ import com.github.zly2006.zhihu.platform.rememberUserMessageSink
 import com.github.zly2006.zhihu.theme.ELDERLY_MODE_PREFERENCE_KEY
 import com.github.zly2006.zhihu.theme.ThemeManager
 import com.github.zly2006.zhihu.theme.ThemeMode
-import com.github.zly2006.zhihu.theme.rememberSystemElderlyModeEnabled
+import com.github.zly2006.zhihu.theme.rememberElderlyModeEnabled
 import com.github.zly2006.zhihu.ui.ANSWER_DOUBLE_TAP_ACTION_PREFERENCE_KEY
 import com.github.zly2006.zhihu.ui.ARTICLE_USE_WEBVIEW_PREFERENCE_KEY
 import com.github.zly2006.zhihu.ui.AnswerDoubleTapAction
@@ -566,27 +566,13 @@ fun AppearanceSettingsScreen(
             SettingItemGroup(
                 title = "阅读",
             ) {
-                val systemElderlyMode = rememberSystemElderlyModeEnabled()
-                var elderlyMode by remember(systemElderlyMode) {
-                    mutableStateOf(settings.getBoolean(ELDERLY_MODE_PREFERENCE_KEY, systemElderlyMode))
-                }
+                val elderlyMode = rememberElderlyModeEnabled()
                 SettingItemWithSwitch(
                     modifier = Modifier.testTag(APPEARANCE_SETTINGS_ELDERLY_MODE_TAG),
                     title = { Text("老年模式") },
-                    description = {
-                        Text(
-                            if (systemElderlyMode) {
-                                "已跟随系统老年模式默认打开，放大界面文字。也可手动开关。"
-                            } else {
-                                "系统老年模式开启时默认打开，放大界面文字。也可手动开关。"
-                            },
-                        )
-                    },
+                    description = { Text("系统老年模式开启时默认打开，放大界面文字。也可手动开关。") },
                     checked = elderlyMode,
-                    onCheckedChange = {
-                        elderlyMode = it
-                        settings.putBoolean(ELDERLY_MODE_PREFERENCE_KEY, it)
-                    },
+                    onCheckedChange = { settings.putBoolean(ELDERLY_MODE_PREFERENCE_KEY, it) },
                     settingKey = ELDERLY_MODE_PREFERENCE_KEY,
                     highlightedKey = settingKey,
                     bringIntoViewRequester = requesterFor(ELDERLY_MODE_PREFERENCE_KEY),

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/subscreens/SettingsSearchScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/subscreens/SettingsSearchScreen.kt
@@ -61,6 +61,7 @@ import com.github.zly2006.zhihu.navigation.NavDestination
 import com.github.zly2006.zhihu.navigation.Notification
 import com.github.zly2006.zhihu.notification.NotificationType
 import com.github.zly2006.zhihu.platform.rememberSettingsStore
+import com.github.zly2006.zhihu.theme.ELDERLY_MODE_PREFERENCE_KEY
 import com.github.zly2006.zhihu.ui.ANSWER_DOUBLE_TAP_ACTION_PREFERENCE_KEY
 import com.github.zly2006.zhihu.ui.ARTICLE_USE_WEBVIEW_PREFERENCE_KEY
 import com.github.zly2006.zhihu.ui.components.SettingItem
@@ -162,6 +163,7 @@ private fun notificationEntry(
 private val settingsSearchEntries = buildList {
     add(appearanceEntry("appearance.nightMode", "主题模式", "切换浅色、深色或跟随系统。", "nightMode", listOf("夜间模式", "深色模式", "暗色模式", "浅色模式", "跟随系统")))
     add(appearanceEntry("appearance.dynamicColor", "使用 Material You 动态取色", "Android 12+ 根据系统壁纸取色。", "dynamicColor", listOf("动态颜色", "壁纸取色", "主题色")))
+    add(appearanceEntry("appearance.elderlyMode", "老年模式", "跟随系统老年模式，也可手动放大界面文字。", ELDERLY_MODE_PREFERENCE_KEY, listOf("长辈模式", "关怀模式", "简易模式", "适老化")))
     add(appearanceEntry("appearance.fontScale", "字号与行高", "调整正文阅读字号和行距。", "fontScale", listOf("字体大小", "内容字体", "正文字号", "行距")))
     add(appearanceEntry("appearance.showFeedThumbnail", "显示 Feed 卡片缩略图", "控制信息流卡片图片显示。", "showFeedThumbnail", listOf("图片", "封面")))
     add(appearanceEntry("appearance.showRefreshFab", "显示刷新 FAB 按钮", "控制首页和列表的浮动刷新按钮。", "showRefreshFab", listOf("刷新按钮", "浮动按钮")))

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/subscreens/SettingsSearchScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/subscreens/SettingsSearchScreen.kt
@@ -163,7 +163,7 @@ private fun notificationEntry(
 private val settingsSearchEntries = buildList {
     add(appearanceEntry("appearance.nightMode", "主题模式", "切换浅色、深色或跟随系统。", "nightMode", listOf("夜间模式", "深色模式", "暗色模式", "浅色模式", "跟随系统")))
     add(appearanceEntry("appearance.dynamicColor", "使用 Material You 动态取色", "Android 12+ 根据系统壁纸取色。", "dynamicColor", listOf("动态颜色", "壁纸取色", "主题色")))
-    add(appearanceEntry("appearance.elderlyMode", "老年模式", "跟随系统老年模式，也可手动放大界面文字。", ELDERLY_MODE_PREFERENCE_KEY, listOf("长辈模式", "关怀模式", "简易模式", "适老化")))
+    add(appearanceEntry("appearance.elderlyMode", "老年模式", "系统老年模式开启时默认打开，放大界面文字。也可手动开关。", ELDERLY_MODE_PREFERENCE_KEY, listOf("长辈模式", "关怀模式", "简易模式", "适老化")))
     add(appearanceEntry("appearance.fontScale", "字号与行高", "调整正文阅读字号和行距。", "fontScale", listOf("字体大小", "内容字体", "正文字号", "行距")))
     add(appearanceEntry("appearance.showFeedThumbnail", "显示 Feed 卡片缩略图", "控制信息流卡片图片显示。", "showFeedThumbnail", listOf("图片", "封面")))
     add(appearanceEntry("appearance.showRefreshFab", "显示刷新 FAB 按钮", "控制首页和列表的浮动刷新按钮。", "showRefreshFab", listOf("刷新按钮", "浮动按钮")))

--- a/shared/src/commonTest/kotlin/com/github/zly2006/zhihu/theme/ElderlyModeTest.kt
+++ b/shared/src/commonTest/kotlin/com/github/zly2006/zhihu/theme/ElderlyModeTest.kt
@@ -11,10 +11,14 @@ class ElderlyModeTest {
         assertTrue(settingValueEnablesElderlyMode(" true "))
         assertTrue(settingValueEnablesElderlyMode("ON"))
         assertTrue(settingValueEnablesElderlyMode("yes"))
+        assertTrue(settingValueEnablesElderlyMode("Yes"))
         assertFalse(settingValueEnablesElderlyMode(null))
         assertFalse(settingValueEnablesElderlyMode("0"))
         assertFalse(settingValueEnablesElderlyMode("false"))
+        assertFalse(settingValueEnablesElderlyMode("off"))
+        assertFalse(settingValueEnablesElderlyMode("no"))
         assertFalse(settingValueEnablesElderlyMode("2"))
         assertFalse(settingValueEnablesElderlyMode(""))
+        assertFalse(settingValueEnablesElderlyMode("   "))
     }
 }

--- a/shared/src/commonTest/kotlin/com/github/zly2006/zhihu/theme/ElderlyModeTest.kt
+++ b/shared/src/commonTest/kotlin/com/github/zly2006/zhihu/theme/ElderlyModeTest.kt
@@ -1,0 +1,30 @@
+package com.github.zly2006.zhihu.theme
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ElderlyModeTest {
+    @Test
+    fun followsSystemWhenUserHasNotSetPreference() {
+        assertTrue(resolveElderlyModeEnabled(stored = null, systemEnabled = true))
+        assertFalse(resolveElderlyModeEnabled(stored = null, systemEnabled = false))
+    }
+
+    @Test
+    fun userToggleOverridesSystemElderlyMode() {
+        assertFalse(resolveElderlyModeEnabled(stored = false, systemEnabled = true))
+        assertTrue(resolveElderlyModeEnabled(stored = true, systemEnabled = false))
+    }
+
+    @Test
+    fun onlyExplicitTruthySettingsEnableSystemElderlyMode() {
+        assertTrue(settingValueEnablesElderlyMode("1"))
+        assertTrue(settingValueEnablesElderlyMode("true"))
+        assertTrue(settingValueEnablesElderlyMode("ON"))
+        assertFalse(settingValueEnablesElderlyMode(null))
+        assertFalse(settingValueEnablesElderlyMode("0"))
+        assertFalse(settingValueEnablesElderlyMode("false"))
+        assertFalse(settingValueEnablesElderlyMode(""))
+    }
+}

--- a/shared/src/commonTest/kotlin/com/github/zly2006/zhihu/theme/ElderlyModeTest.kt
+++ b/shared/src/commonTest/kotlin/com/github/zly2006/zhihu/theme/ElderlyModeTest.kt
@@ -6,25 +6,15 @@ import kotlin.test.assertTrue
 
 class ElderlyModeTest {
     @Test
-    fun followsSystemWhenUserHasNotSetPreference() {
-        assertTrue(resolveElderlyModeEnabled(stored = null, systemEnabled = true))
-        assertFalse(resolveElderlyModeEnabled(stored = null, systemEnabled = false))
-    }
-
-    @Test
-    fun userToggleOverridesSystemElderlyMode() {
-        assertFalse(resolveElderlyModeEnabled(stored = false, systemEnabled = true))
-        assertTrue(resolveElderlyModeEnabled(stored = true, systemEnabled = false))
-    }
-
-    @Test
     fun onlyExplicitTruthySettingsEnableSystemElderlyMode() {
         assertTrue(settingValueEnablesElderlyMode("1"))
-        assertTrue(settingValueEnablesElderlyMode("true"))
+        assertTrue(settingValueEnablesElderlyMode(" true "))
         assertTrue(settingValueEnablesElderlyMode("ON"))
+        assertTrue(settingValueEnablesElderlyMode("yes"))
         assertFalse(settingValueEnablesElderlyMode(null))
         assertFalse(settingValueEnablesElderlyMode("0"))
         assertFalse(settingValueEnablesElderlyMode("false"))
+        assertFalse(settingValueEnablesElderlyMode("2"))
         assertFalse(settingValueEnablesElderlyMode(""))
     }
 }

--- a/shared/src/jvmMain/kotlin/com/github/zly2006/zhihu/platform/JvmPlatformCapabilities.kt
+++ b/shared/src/jvmMain/kotlin/com/github/zly2006/zhihu/platform/JvmPlatformCapabilities.kt
@@ -29,6 +29,7 @@ import com.github.zly2006.zhihu.desktop.openDesktopExternalUrl
 import com.github.zly2006.zhihu.desktop.saveImageToDownloads
 import kotlinx.coroutines.launch
 import kotlinx.io.files.Path
+import java.util.concurrent.CopyOnWriteArrayList
 
 @Composable
 actual fun rememberSettingsStore(): SettingsStore = remember { desktopSettingsStore() }
@@ -38,63 +39,101 @@ actual fun Modifier.exportTestTagsForUiAutomation(): Modifier = this
 @Composable
 actual fun rememberAppPrivateDirectory(): Path = remember { Path(desktopZhihuDataDir().absolutePath) }
 
-fun desktopSettingsStore(): SettingsStore {
+private val desktopSettingsLock = Any()
+private val desktopSettingsKeyListeners = CopyOnWriteArrayList<(String) -> Unit>()
+private var cachedDesktopSettingsStore: SettingsStore? = null
+
+/**
+ * 桌面设置必须单例。每次新建一份内存 Properties 时，设置页写入后主题层读到的仍是旧副本；
+ * 老年模式依赖 observeKeyChanges 立刻改 fontScale，不能各读各的。
+ */
+fun desktopSettingsStore(): SettingsStore = synchronized(desktopSettingsLock) {
+    cachedDesktopSettingsStore ?: createDesktopSettingsStore().also { cachedDesktopSettingsStore = it }
+}
+
+private fun createDesktopSettingsStore(): SettingsStore {
     val propertiesFile = DesktopPropertiesFile("settings.properties", "Zhihu++ desktop settings")
     val properties = propertiesFile.properties
 
+    fun persist(
+        key: String,
+        mutate: () -> Unit,
+    ) {
+        synchronized(desktopSettingsLock) {
+            mutate()
+            propertiesFile.save()
+        }
+        desktopSettingsKeyListeners.forEach { listener -> listener(key) }
+    }
+
     return SettingsStore(
         getBoolean = { key, defaultValue ->
-            properties.getProperty(key)?.toBooleanStrictOrNull() ?: defaultValue
+            synchronized(desktopSettingsLock) {
+                properties.getProperty(key)?.toBooleanStrictOrNull() ?: defaultValue
+            }
         },
         putBoolean = { key, value ->
-            properties.setProperty(key, value.toString())
-            propertiesFile.save()
+            persist(key) { properties.setProperty(key, value.toString()) }
         },
         getString = { key, defaultValue ->
-            properties.getProperty(key) ?: defaultValue
+            synchronized(desktopSettingsLock) {
+                properties.getProperty(key) ?: defaultValue
+            }
         },
         putString = { key, value ->
-            properties.setProperty(key, value)
-            propertiesFile.save()
+            persist(key) { properties.setProperty(key, value) }
         },
         getStringOrNull = { key ->
-            properties.getProperty(key)
+            synchronized(desktopSettingsLock) {
+                properties.getProperty(key)
+            }
         },
         putStringSet = { key, value ->
-            properties.setProperty(key, value.joinToString("\u001F"))
-            propertiesFile.save()
+            persist(key) { properties.setProperty(key, value.joinToString("\u001F")) }
         },
         getStringSet = { key, defaultValue ->
-            properties
-                .getProperty(key)
-                ?.split("\u001F")
-                ?.filter { it.isNotEmpty() }
-                ?.toSet() ?: defaultValue
+            synchronized(desktopSettingsLock) {
+                properties
+                    .getProperty(key)
+                    ?.split("\u001F")
+                    ?.filter { it.isNotEmpty() }
+                    ?.toSet() ?: defaultValue
+            }
         },
         getInt = { key, defaultValue ->
-            properties.getProperty(key)?.toIntOrNull() ?: defaultValue
+            synchronized(desktopSettingsLock) {
+                properties.getProperty(key)?.toIntOrNull() ?: defaultValue
+            }
         },
         putInt = { key, value ->
-            properties.setProperty(key, value.toString())
-            propertiesFile.save()
+            persist(key) { properties.setProperty(key, value.toString()) }
         },
         getLong = { key, defaultValue ->
-            properties.getProperty(key)?.toLongOrNull() ?: defaultValue
+            synchronized(desktopSettingsLock) {
+                properties.getProperty(key)?.toLongOrNull() ?: defaultValue
+            }
         },
         putLong = { key, value ->
-            properties.setProperty(key, value.toString())
-            propertiesFile.save()
+            persist(key) { properties.setProperty(key, value.toString()) }
         },
         getFloat = { key, defaultValue ->
-            properties.getProperty(key)?.toFloatOrNull() ?: defaultValue
+            synchronized(desktopSettingsLock) {
+                properties.getProperty(key)?.toFloatOrNull() ?: defaultValue
+            }
         },
         putFloat = { key, value ->
-            properties.setProperty(key, value.toString())
-            propertiesFile.save()
+            persist(key) { properties.setProperty(key, value.toString()) }
         },
         remove = { key ->
-            properties.remove(key)
-            propertiesFile.save()
+            persist(key) { properties.remove(key) }
+        },
+        observeKeyChanges = { onChanged ->
+            desktopSettingsKeyListeners.add(onChanged)
+            val unregister = {
+                desktopSettingsKeyListeners.remove(onChanged)
+                Unit
+            }
+            unregister
         },
     )
 }

--- a/shared/src/jvmMain/kotlin/com/github/zly2006/zhihu/theme/ElderlyMode.jvm.kt
+++ b/shared/src/jvmMain/kotlin/com/github/zly2006/zhihu/theme/ElderlyMode.jvm.kt
@@ -1,0 +1,23 @@
+/*
+ * Zhihu++ - Free & Ad-Free Zhihu client for all platforms.
+ * Copyright (C) 2024-2026, zly2006 <i@zly2006.me>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation (version 3 only).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.github.zly2006.zhihu.theme
+
+import androidx.compose.runtime.Composable
+
+@Composable
+actual fun rememberSystemElderlyModeEnabled(): Boolean = false

--- a/shared/src/jvmTest/kotlin/com/github/zly2006/zhihu/platform/DesktopSettingsStoreTest.kt
+++ b/shared/src/jvmTest/kotlin/com/github/zly2006/zhihu/platform/DesktopSettingsStoreTest.kt
@@ -1,0 +1,11 @@
+package com.github.zly2006.zhihu.platform
+
+import kotlin.test.Test
+import kotlin.test.assertSame
+
+class DesktopSettingsStoreTest {
+    @Test
+    fun desktopSettingsStoreIsSharedSingleton() {
+        assertSame(desktopSettingsStore(), desktopSettingsStore())
+    }
+}

--- a/shared/src/nativeMain/kotlin/com/github/zly2006/zhihu/theme/ElderlyMode.native.kt
+++ b/shared/src/nativeMain/kotlin/com/github/zly2006/zhihu/theme/ElderlyMode.native.kt
@@ -1,0 +1,23 @@
+/*
+ * Zhihu++ - Free & Ad-Free Zhihu client for all platforms.
+ * Copyright (C) 2024-2026, zly2006 <i@zly2006.me>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation (version 3 only).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.github.zly2006.zhihu.theme
+
+import androidx.compose.runtime.Composable
+
+@Composable
+actual fun rememberSystemElderlyModeEnabled(): Boolean = false


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 必填：AI 使用与验证材料

请如实勾选：

- [ ] 未使用 AI 编写、改写或批量生成代码
- [x] 使用了 AI 编写、改写或批量生成代码

如果使用了 AI，本 PR 必须附上以下验证材料，否则不会进入 review：

- [ ] 已上传测试截图
- [ ] 已上传测试录屏

当前 Cloud Agent 环境没有可用 AVD，无法安装 Lite Debug APK 做真实页面截图。已完成 `assembleLiteDebug`、`ktlintFormat`、`ElderlyModeTest` 和桌面设置单例测试。外观页开关测试 `AppearanceSettingsScreenInstrumentedTest.togglingElderlyModePersistsOverride` 交给 GitHub CI。

## 变更说明

新增应用内老年模式：

- 先读取手机系统的老年/简易/关怀模式。AOSP 没有统一 API，因此只认厂商已经写入的 Settings 键；键不存在或不是真值，不当成已开启。
- 用户还没动过开关时，系统开了就默认打开。
- 外观设置里可以随时手动打开或关闭，写入后覆盖系统默认。
- 开启后只放大界面 `sp` 文字（1.25 倍），不改 `dp` 密度，避免整页布局被二次缩放。正文仍叠加原来的字号百分比。

入口在「外观与阅读体验 → 阅读 → 老年模式」。设置搜索也能跳到这一项。

## 审计

连续审计后已修掉这些问题：

1. 系统开着但用户关掉后，说明不再声称“已跟随默认打开”。
2. 设置页和主题共用 `rememberElderlyModeEnabled`，不再各持一份开关状态。
3. 厂商 Settings 读取失败时不当成已开启；键列表只留在 Android。
4. instrumented 测试按当前系统状态计算期望覆盖值。
5. 桌面设置改为进程内单例，并实现 `observeKeyChanges`。否则设置页写入后主题仍读旧的内存副本，开关和字号都不会立刻变。
6. 设置搜索说明与外观页固定规则文案对齐。
7. 注明必须用 `getString` 读厂商键，避免后续改成旧 MIUI `isSimpleMode` 那种 `getInt(..., 1)` 把缺失键误判为开启。

后续几轮未再发现需要改的问题。以下边界是有意保留的：不按厂商门控键扩大检测、不挂 ContentObserver、不给 `fontScale` 加上限、不改废弃 WebView 路径。系统老年模式本身已放大字体时，应用再乘 1.25；用户可以关掉应用开关。

## 测试与验证

- `./gradlew assembleLiteDebug`
- `./gradlew ktlintFormat`
- `./gradlew :shared:compileKotlinJvm`
- `./gradlew :shared:jvmTest --tests com.github.zly2006.zhihu.theme.ElderlyModeTest`
- `./gradlew :shared:jvmTest --tests com.github.zly2006.zhihu.platform.DesktopSettingsStoreTest`
- `AppearanceSettingsScreenInstrumentedTest.togglingElderlyModePersistsOverride`（CI instrumented）

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-352b837c-d520-478f-a39f-58a71585b3ca?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-352b837c-d520-478f-a39f-58a71585b3ca&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

