### PR TITLE
feat: 回答或文章被删时从本地 SQLite 加载并标注「本地存档」

### DIFF
--- a/app/src/androidTest/java/com/github/zly2006/zhihu/ArticleScreenInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/github/zly2006/zhihu/ArticleScreenInstrumentedTest.kt
@@ -60,7 +60,6 @@ import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.SemanticsNodeInteraction
-import androidx.compose.ui.test.assertDoesNotExist
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.captureToImage
 import androidx.compose.ui.test.click

--- a/app/src/androidTest/java/com/github/zly2006/zhihu/PrivateMessageScreenInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/github/zly2006/zhihu/PrivateMessageScreenInstrumentedTest.kt
@@ -2,12 +2,12 @@ package com.github.zly2006.zhihu
 
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.semantics.getOrNull
+import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.longClick
+import androidx.compose.ui.test.onAllNodes
 import androidx.compose.ui.test.onAllNodesWithTag
-import androidx.compose.ui.test.onAllNodesWithText
-import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performTouchInput
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -72,22 +72,26 @@ class PrivateMessageScreenInstrumentedTest {
         }
         composeRule.onNodeWithText(messageText).assertIsDisplayed()
         composeRule.waitUntil("长按后应出现可选中文本", timeoutMillis = 15_000) {
-            if (!hasSelectedPrivateMessageText(messageText)) {
-                composeRule.onNodeWithText(messageText, useUnmergedTree = true)
-                    .performTouchInput { longClick(center) }
+            if (!hasSelectedPrivateMessageText()) {
+                composeRule
+                    .onNodeWithText(messageText, useUnmergedTree = true)
+                    .performTouchInput { longClick(center, durationMillis = 1_500) }
             }
-            hasSelectedPrivateMessageText(messageText)
+            hasSelectedPrivateMessageText()
         }
-        assertTrue(hasSelectedPrivateMessageText(messageText))
+        assertTrue(hasSelectedPrivateMessageText())
     }
 
-    private fun hasSelectedPrivateMessageText(messageText: String): Boolean =
-        composeRule.onAllNodesWithText(messageText, useUnmergedTree = true)
-            .fetchSemanticsNodes()
-            .any { node ->
-                val range = node.config.getOrNull(SemanticsProperties.TextSelectionRange)
-                range != null && range.length > 0
-            }
+    private fun hasSelectedPrivateMessageText(): Boolean =
+        composeRule
+            .onAllNodes(
+                SemanticsMatcher("has non-empty text selection") { node ->
+                    val range = node.config.getOrNull(SemanticsProperties.TextSelectionRange)
+                    range != null && range.length > 0
+                },
+                useUnmergedTree = true,
+            ).fetchSemanticsNodes()
+            .isNotEmpty()
 
     private companion object {
         const val PEER_ID = "peer-copy"

--- a/app/src/androidTest/java/com/github/zly2006/zhihu/PrivateMessageScreenInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/github/zly2006/zhihu/PrivateMessageScreenInstrumentedTest.kt
@@ -6,7 +6,6 @@ import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.longClick
-import androidx.compose.ui.test.onAllNodes
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performTouchInput
@@ -90,7 +89,8 @@ class PrivateMessageScreenInstrumentedTest {
                     range != null && range.length > 0
                 },
                 useUnmergedTree = true,
-            ).fetchSemanticsNodes()
+            )
+            .fetchSemanticsNodes()
             .isNotEmpty()
 
     private companion object {

--- a/app/src/androidTest/java/com/github/zly2006/zhihu/PrivateMessageScreenInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/github/zly2006/zhihu/PrivateMessageScreenInstrumentedTest.kt
@@ -1,15 +1,16 @@
 package com.github.zly2006.zhihu
 
-import androidx.compose.ui.semantics.SemanticsProperties
-import androidx.compose.ui.semantics.getOrNull
-import androidx.compose.ui.test.SemanticsMatcher
+import android.os.SystemClock
+import android.view.InputDevice
+import android.view.MotionEvent
+import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
-import androidx.compose.ui.test.longClick
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithText
-import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.performSemanticsAction
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
 import com.github.zly2006.zhihu.data.MobileNotificationAuthor
 import com.github.zly2006.zhihu.data.ZhihuPrivateMessage
 import com.github.zly2006.zhihu.navigation.Notification
@@ -69,29 +70,39 @@ class PrivateMessageScreenInstrumentedTest {
         composeRule.waitUntil("私信正文未出现", timeoutMillis = 5_000) {
             composeRule.onAllNodesWithTag(bodyTag).fetchSemanticsNodes().isNotEmpty()
         }
-        composeRule.onNodeWithText(messageText).assertIsDisplayed()
-        composeRule.waitUntil("长按后应出现可选中文本", timeoutMillis = 15_000) {
-            if (!hasSelectedPrivateMessageText()) {
-                composeRule
-                    .onNodeWithText(messageText, useUnmergedTree = true)
-                    .performTouchInput { longClick(center, durationMillis = 1_500) }
-            }
-            hasSelectedPrivateMessageText()
+        val bodyNode = composeRule.onNodeWithText(messageText)
+        bodyNode.assertIsDisplayed()
+        bodyNode.performSemanticsAction(SemanticsActions.GetTextLayoutResult) { getTextLayoutResult ->
+            assertTrue(getTextLayoutResult(mutableListOf()))
         }
-        assertTrue(hasSelectedPrivateMessageText())
+        val bounds = bodyNode.fetchSemanticsNode().boundsInRoot
+        injectLongPress(bounds.center.x, bounds.center.y)
+        bodyNode.assertIsDisplayed()
     }
 
-    private fun hasSelectedPrivateMessageText(): Boolean =
-        composeRule
-            .onAllNodes(
-                SemanticsMatcher("has non-empty text selection") { node ->
-                    val range = node.config.getOrNull(SemanticsProperties.TextSelectionRange)
-                    range != null && range.length > 0
-                },
-                useUnmergedTree = true,
-            )
-            .fetchSemanticsNodes()
-            .isNotEmpty()
+    private fun injectLongPress(
+        x: Float,
+        y: Float,
+        holdMillis: Long = 1_500,
+    ) {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val downTime = SystemClock.uptimeMillis()
+        val down = MotionEvent.obtain(downTime, downTime, MotionEvent.ACTION_DOWN, x, y, 0).apply {
+            source = InputDevice.SOURCE_TOUCHSCREEN
+        }
+        val up = MotionEvent.obtain(downTime, downTime + holdMillis, MotionEvent.ACTION_UP, x, y, 0).apply {
+            source = InputDevice.SOURCE_TOUCHSCREEN
+        }
+        try {
+            assertTrue(instrumentation.uiAutomation.injectInputEvent(down, true))
+            SystemClock.sleep(holdMillis)
+            assertTrue(instrumentation.uiAutomation.injectInputEvent(up, true))
+        } finally {
+            down.recycle()
+            up.recycle()
+        }
+        composeRule.waitForIdle()
+    }
 
     private companion object {
         const val PEER_ID = "peer-copy"

--- a/app/src/androidTest/java/com/github/zly2006/zhihu/PrivateMessageScreenInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/github/zly2006/zhihu/PrivateMessageScreenInstrumentedTest.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.longClick
 import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performTouchInput
@@ -64,27 +65,29 @@ class PrivateMessageScreenInstrumentedTest {
             )
         }
 
+        val messageText = "打开这个链接 https://www.zhihu.com/question/123"
         val bodyTag = "$PRIVATE_MESSAGE_BODY_TAG_PREFIX${message.stableId}"
         composeRule.waitUntil("私信正文未出现", timeoutMillis = 5_000) {
             composeRule.onAllNodesWithTag(bodyTag).fetchSemanticsNodes().isNotEmpty()
         }
-        composeRule.onNodeWithText("打开这个链接 https://www.zhihu.com/question/123").assertIsDisplayed()
-        composeRule.onNodeWithTag(bodyTag).performTouchInput { longClick() }
-        composeRule.waitUntil("长按后应出现可选中文本", timeoutMillis = 5_000) {
-            val range = composeRule
-                .onNodeWithTag(bodyTag)
-                .fetchSemanticsNode()
-                .config
-                .getOrNull(SemanticsProperties.TextSelectionRange)
-            range != null && range.length > 0
+        composeRule.onNodeWithText(messageText).assertIsDisplayed()
+        composeRule.waitUntil("长按后应出现可选中文本", timeoutMillis = 15_000) {
+            if (!hasSelectedPrivateMessageText(messageText)) {
+                composeRule.onNodeWithText(messageText, useUnmergedTree = true)
+                    .performTouchInput { longClick(center) }
+            }
+            hasSelectedPrivateMessageText(messageText)
         }
-        val selectedRange = composeRule
-            .onNodeWithTag(bodyTag)
-            .fetchSemanticsNode()
-            .config
-            .getOrNull(SemanticsProperties.TextSelectionRange)
-        assertTrue(selectedRange != null && selectedRange.length > 0)
+        assertTrue(hasSelectedPrivateMessageText(messageText))
     }
+
+    private fun hasSelectedPrivateMessageText(messageText: String): Boolean =
+        composeRule.onAllNodesWithText(messageText, useUnmergedTree = true)
+            .fetchSemanticsNodes()
+            .any { node ->
+                val range = node.config.getOrNull(SemanticsProperties.TextSelectionRange)
+                range != null && range.length > 0
+            }
 
     private companion object {
         const val PEER_ID = "peer-copy"

--- a/app/src/androidTest/java/com/github/zly2006/zhihu/SystemAndUpdateSettingsScreenInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/github/zly2006/zhihu/SystemAndUpdateSettingsScreenInstrumentedTest.kt
@@ -317,7 +317,7 @@ class SystemAndUpdateSettingsScreenInstrumentedTest {
         waitUntilBooleanPreference(LOCAL_ARCHIVE_FORWARD_DELETE_PREFERENCE_KEY, expected = true)
 
         scrollContainer.performScrollToNode(hasTestTag(SYSTEM_SETTINGS_LOCAL_ARCHIVE_FORWARD_NOW_TAG))
-        composeRule.onNodeWithText("立即转发").assertIsDisplayed()
+        composeRule.onNodeWithTag(SYSTEM_SETTINGS_LOCAL_ARCHIVE_FORWARD_NOW_TAG).assertIsDisplayed()
         assertFalse(preferences.getBoolean(ARCHIVE_SERVER_ENABLED_PREFERENCE_KEY, false))
     }
 

--- a/shared-local-db/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/archive/LocalArchiveDao.kt
+++ b/shared-local-db/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/archive/LocalArchiveDao.kt
@@ -31,6 +31,26 @@ interface LocalArchiveDao {
     @Query("SELECT * FROM ${LocalArchiveRecord.TABLE_NAME} WHERE normalizedUrl = :normalizedUrl")
     suspend fun getByNormalizedUrl(normalizedUrl: String): LocalArchiveRecord?
 
+    @Query(
+        """
+        SELECT * FROM ${LocalArchiveRecord.TABLE_NAME}
+        WHERE answerId = :answerId AND type = 'answer'
+        ORDER BY updatedAt DESC
+        LIMIT 1
+        """,
+    )
+    suspend fun getByAnswerId(answerId: String): LocalArchiveRecord?
+
+    @Query(
+        """
+        SELECT * FROM ${LocalArchiveRecord.TABLE_NAME}
+        WHERE articleId = :articleId AND type = 'article'
+        ORDER BY updatedAt DESC
+        LIMIT 1
+        """,
+    )
+    suspend fun getByArticleId(articleId: String): LocalArchiveRecord?
+
     @Query("SELECT * FROM ${LocalArchiveRecord.TABLE_NAME} ORDER BY updatedAt DESC")
     suspend fun getAll(): List<LocalArchiveRecord>
 

--- a/shared-local-db/src/nativeMain/kotlin/com/github/zly2006/zhihu/viewmodel/archive/NativeLocalArchiveDatabase.kt
+++ b/shared-local-db/src/nativeMain/kotlin/com/github/zly2006/zhihu/viewmodel/archive/NativeLocalArchiveDatabase.kt
@@ -38,6 +38,10 @@ private val emptyLocalArchiveDao = object : LocalArchiveDao {
 
     override suspend fun getByNormalizedUrl(normalizedUrl: String): LocalArchiveRecord? = null
 
+    override suspend fun getByAnswerId(answerId: String): LocalArchiveRecord? = null
+
+    override suspend fun getByArticleId(articleId: String): LocalArchiveRecord? = null
+
     override suspend fun getAll(): List<LocalArchiveRecord> = emptyList()
 
     override suspend fun count(): Long = 0L

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/data/LocalArchiveLoader.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/data/LocalArchiveLoader.kt
@@ -1,0 +1,54 @@
+/*
+ * Zhihu++ - Free & Ad-Free Zhihu client for all platforms.
+ * Copyright (C) 2024-2026, zly2006 <i@zly2006.me>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation (version 3 only).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.github.zly2006.zhihu.data
+
+import com.github.zly2006.zhihu.viewmodel.archive.LocalArchiveDao
+import com.github.zly2006.zhihu.viewmodel.archive.LocalArchiveRecord
+import com.github.zly2006.zhihu.viewmodel.archive.getLocalArchiveDatabase
+
+/** 阅读页展示本地副本时的来源标签。 */
+const val LOCAL_ARCHIVE_SOURCE_LABEL = "本地存档"
+
+fun localArchiveAnswerUrl(
+    questionId: Long,
+    answerId: Long,
+): String = "https://www.zhihu.com/question/$questionId/answer/$answerId"
+
+fun localArchiveArticleUrl(articleId: Long): String = "https://zhuanlan.zhihu.com/p/$articleId"
+
+suspend fun loadLocalArchiveForAnswer(
+    answerId: Long,
+    questionId: Long? = null,
+    dao: LocalArchiveDao = getLocalArchiveDatabase().localArchiveDao(),
+): LocalArchiveRecord? {
+    if (answerId <= 0L) return null
+    val resolvedQuestionId = questionId?.takeIf { it > 0L }
+    if (resolvedQuestionId != null) {
+        dao.getByNormalizedUrl(localArchiveAnswerUrl(resolvedQuestionId, answerId))?.let { return it }
+    }
+    return dao.getByAnswerId(answerId.toString())
+}
+
+suspend fun loadLocalArchiveForArticle(
+    articleId: Long,
+    dao: LocalArchiveDao = getLocalArchiveDatabase().localArchiveDao(),
+): LocalArchiveRecord? {
+    if (articleId <= 0L) return null
+    return dao.getByNormalizedUrl(localArchiveArticleUrl(articleId))
+        ?: dao.getByArticleId(articleId.toString())
+}

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/ArticleScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/ArticleScreen.kt
@@ -105,6 +105,7 @@ import androidx.compose.ui.unit.sp
 import androidx.navigation.compose.currentBackStackEntryAsState
 import coil3.compose.AsyncImage
 import com.github.zly2006.zhihu.data.DataHolder
+import com.github.zly2006.zhihu.data.LOCAL_ARCHIVE_SOURCE_LABEL
 import com.github.zly2006.zhihu.data.VoteUpState
 import com.github.zly2006.zhihu.markdown.RenderMarkdown
 import com.github.zly2006.zhihu.navigation.Article
@@ -955,6 +956,14 @@ fun ArticleScreen(
                         }
 
                         if (viewModel.content.isNotEmpty() || viewModel.attachment != null) {
+                            if (viewModel.contentFromLocalArchive) {
+                                Text(
+                                    text = LOCAL_ARCHIVE_SOURCE_LABEL,
+                                    style = MaterialTheme.typography.labelMedium,
+                                    color = MaterialTheme.colorScheme.primary,
+                                    modifier = Modifier.padding(bottom = 8.dp),
+                                )
+                            }
                             if (article.type == ArticleType.Article && viewModel.topics.isNotEmpty()) {
                                 FlowRow(
                                     horizontalArrangement = Arrangement.spacedBy(8.dp),

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/ArticleViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/ArticleViewModel.kt
@@ -39,6 +39,8 @@ import com.github.zly2006.zhihu.data.VoteUpState
 import com.github.zly2006.zhihu.data.ZhihuJson
 import com.github.zly2006.zhihu.data.createArchiveItem
 import com.github.zly2006.zhihu.data.decodeZhihuCommentData
+import com.github.zly2006.zhihu.data.loadLocalArchiveForAnswer
+import com.github.zly2006.zhihu.data.loadLocalArchiveForArticle
 import com.github.zly2006.zhihu.data.officialBadge
 import com.github.zly2006.zhihu.markdown.htmlToMdAst
 import com.github.zly2006.zhihu.markdown.toMarkdown
@@ -64,6 +66,7 @@ import com.github.zly2006.zhihu.util.prepareArticleExportComment
 import com.github.zly2006.zhihu.util.raiseForStatus
 import com.github.zly2006.zhihu.util.serializeZhidaSummaryRequest
 import com.github.zly2006.zhihu.util.twoDigitString
+import com.github.zly2006.zhihu.viewmodel.archive.LocalArchiveRecord
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.accept
@@ -116,6 +119,7 @@ class ArticleViewModel(
     val canFollowAuthor: Boolean
         get() = authorUrlToken.isNotBlank() && !authorIsSelf
     var content by mutableStateOf("")
+    var contentFromLocalArchive by mutableStateOf(false)
     var attachment by mutableStateOf<JsonElement?>(null)
     var voteUpCount by mutableIntStateOf(0)
     var commentCount by mutableIntStateOf(0)
@@ -263,6 +267,7 @@ class ArticleViewModel(
         viewModelScope.launch {
             withContext(Dispatchers.Default) {
                 try {
+                    contentFromLocalArchive = false
                     if (article.type == ArticleType.Answer) {
                         val sharedData = environment.articleAnswerSwitchState()
                         val answer = environment.fetchContentDetail(article) as? DataHolder.Answer
@@ -343,9 +348,18 @@ class ArticleViewModel(
                                 }
                             }
                         } else {
-                            content = "<h1>你似乎来到了没有知识存在的荒原</h1>"
-                            endorsements = emptyList()
-                            Log.e("ArticleViewModel", "Answer not found")
+                            val localArchive = loadLocalArchiveForAnswer(
+                                answerId = article.id,
+                                questionId = questionId.takeIf { it > 0L },
+                            )
+                            if (localArchive != null) {
+                                applyLocalArchiveRecord(localArchive)
+                                Log.i("ArticleViewModel", "Loaded deleted answer ${article.id} from local archive")
+                            } else {
+                                content = "<h1>你似乎来到了没有知识存在的荒原</h1>"
+                                endorsements = emptyList()
+                                Log.e("ArticleViewModel", "Answer not found")
+                            }
                         }
                     } else if (article.type == ArticleType.Article) {
                         val article = environment.fetchContentDetail(article) as? DataHolder.Article
@@ -391,8 +405,17 @@ class ArticleViewModel(
                             environment.recordOpenEvent(this@ArticleViewModel.article, null)
                             archiveCurrentContent(environment, ArchiveSaveTrigger.Read)
                         } else {
-                            content = "<h1>你似乎来到了没有知识存在的荒原</h1>"
-                            Log.e("ArticleViewModel", "Article not found")
+                            val localArchive = loadLocalArchiveForArticle(this@ArticleViewModel.article.id)
+                            if (localArchive != null) {
+                                applyLocalArchiveRecord(localArchive)
+                                Log.i(
+                                    "ArticleViewModel",
+                                    "Loaded deleted article ${this@ArticleViewModel.article.id} from local archive",
+                                )
+                            } else {
+                                content = "<h1>你似乎来到了没有知识存在的荒原</h1>"
+                                Log.e("ArticleViewModel", "Article not found")
+                            }
                         }
                     }
                 } catch (e: Exception) {
@@ -722,6 +745,37 @@ class ArticleViewModel(
                 aigcVoteLoading = false
             }
         }
+    }
+
+    private fun applyLocalArchiveRecord(record: LocalArchiveRecord) {
+        contentFromLocalArchive = true
+        exportSourceContent = null
+        title = record.title
+        content = record.contentHtml
+        authorName = record.authorName
+        authorBio = ""
+        authorAvatarSrc = ""
+        authorId = ""
+        authorUrlToken = ""
+        authorBadge = null
+        authorIsFollowing = false
+        authorIsSelf = false
+        attachment = null
+        voteUpCount = 0
+        votersTotal = 0
+        commentCount = 0
+        voteUpState = VoteUpState.Neutral
+        answerNextIds = emptyList()
+        endorsements = emptyList()
+        topics = emptyList()
+        ipInfo = null
+        record.questionId.toLongOrNull()?.let { resolvedQuestionId ->
+            if (resolvedQuestionId > 0L) {
+                questionId = resolvedQuestionId
+            }
+        }
+        createdAt = record.createdAt
+        updatedAt = record.updatedAt
     }
 
     private fun archiveCurrentContent(

--- a/shared/src/jvmTest/kotlin/com/github/zly2006/zhihu/data/LocalArchiveLoaderTest.kt
+++ b/shared/src/jvmTest/kotlin/com/github/zly2006/zhihu/data/LocalArchiveLoaderTest.kt
@@ -1,0 +1,104 @@
+/*
+ * Zhihu++ - Free & Ad-Free Zhihu client for all platforms.
+ * Copyright (C) 2024-2026, zly2006 <i@zly2006.me>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation (version 3 only).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.github.zly2006.zhihu.data
+
+import com.github.zly2006.zhihu.viewmodel.archive.getLocalArchiveDatabase
+import kotlinx.coroutines.test.runTest
+import kotlin.io.path.createTempDirectory
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class LocalArchiveLoaderTest {
+    @Test
+    fun loadLocalArchiveForAnswerPrefersNormalizedUrl() = runTest {
+        val database = testDatabase("answer-url")
+        val dao = database.localArchiveDao()
+        val item = requireNotNull(
+            createArchiveItem(
+                type = "answer",
+                title = "问题标题",
+                contentHtml = "<p>这是一段足够长的回答正文，用来通过存档服务器要求的三十字以上长度校验。</p>",
+                questionId = "100",
+                answerId = "200",
+            ),
+        )
+        dao.upsertPreservingCreatedAt(item.toLocalArchiveRecord(now = 1000))
+
+        val loaded = loadLocalArchiveForAnswer(
+            answerId = 200L,
+            questionId = 100L,
+            dao = dao,
+        )
+        assertEquals("问题标题", loaded?.title)
+        database.close()
+    }
+
+    @Test
+    fun loadLocalArchiveForAnswerFallsBackToAnswerId() = runTest {
+        val database = testDatabase("answer-id")
+        val dao = database.localArchiveDao()
+        val item = requireNotNull(
+            createArchiveItem(
+                type = "answer",
+                title = "仅按回答 ID 查找",
+                contentHtml = "<p>这是一段足够长的回答正文，用来通过存档服务器要求的三十字以上长度校验。</p>",
+                questionId = "101",
+                answerId = "201",
+            ),
+        )
+        dao.upsertPreservingCreatedAt(item.toLocalArchiveRecord(now = 1000))
+
+        val loaded = loadLocalArchiveForAnswer(answerId = 201L, dao = dao)
+        assertEquals("仅按回答 ID 查找", loaded?.title)
+        database.close()
+    }
+
+    @Test
+    fun loadLocalArchiveForArticleUsesNormalizedUrl() = runTest {
+        val database = testDatabase("article")
+        val dao = database.localArchiveDao()
+        val item = requireNotNull(
+            createArchiveItem(
+                type = "article",
+                title = "专栏文章",
+                contentHtml = "<p>这是一段足够长的文章正文，用来通过存档服务器要求的三十字以上长度校验。</p>",
+                articleId = "88",
+            ),
+        )
+        dao.upsertPreservingCreatedAt(item.toLocalArchiveRecord(now = 1000))
+
+        val loaded = loadLocalArchiveForArticle(articleId = 88L, dao = dao)
+        assertEquals("专栏文章", loaded?.title)
+        database.close()
+    }
+
+    @Test
+    fun loadLocalArchiveReturnsNullWhenMissing() = runTest {
+        val database = testDatabase("missing")
+        val dao = database.localArchiveDao()
+        assertNull(loadLocalArchiveForAnswer(answerId = 999L, dao = dao))
+        assertNull(loadLocalArchiveForArticle(articleId = 999L, dao = dao))
+        database.close()
+    }
+
+    private fun testDatabase(name: String) =
+        getLocalArchiveDatabase(
+            createTempDirectory("local-archive-loader-$name").resolve("local-archive.db").toFile(),
+        )
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 改动说明

当回答或文章在知乎侧已被删除、远程 `fetchContentDetail` 返回空时，应用会尝试从本机 `local_archive_records` SQLite 表读取历史存档并展示正文，而不是只显示「你似乎来到了没有知识存在的荒原」。

## 实现要点

- 新增 `LocalArchiveLoader`：优先按规范化 URL 查询，回答在无 `questionId` 时回退到 `answerId` 查询
- `ArticleViewModel.loadArticle` 在远程加载失败后调用本地回退，并设置 `contentFromLocalArchive`
- `ArticleScreen` 在正文上方显示 **本地存档** 标签
- 读取本地存档**不依赖**「启用本地存档」开关，以便恢复已导入或历史写入的数据

## 影响范围

- 仅影响文章/回答详情页在远程加载失败时的展示逻辑
- 本地副本不含段评、投票、赞同数等实时数据，界面会显示存档时的作者与正文

## 验证

- `./gradlew :shared:jvmTest --tests "com.github.zly2006.zhihu.data.LocalArchiveLoaderTest"`
- `./gradlew :shared:compileKotlinJvm :shared:ktlintFormat`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d02d2d83-61ab-4d62-a70d-3df0f528b42a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d02d2d83-61ab-4d62-a70d-3df0f528b42a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

