### PR TITLE
feat: 将正文字号滑条改为 5% 一档

### DIFF
--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/subscreens/AppearanceSettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/subscreens/AppearanceSettingsScreen.kt
@@ -590,11 +590,12 @@ fun AppearanceSettingsScreen(
                         Slider(
                             value = fontSize.toFloat(),
                             onValueChange = {
-                                fontSize = it.toInt()
-                                settings.putInt(PREF_FONT_SIZE, it.toInt())
+                                val size = (it / 5).roundToInt() * 5
+                                fontSize = size
+                                settings.putInt(PREF_FONT_SIZE, size)
                             },
                             valueRange = 50f..200f,
-                            steps = 14,
+                            steps = 29,
                             modifier = Modifier.fillMaxWidth().padding(top = 8.dp),
                         )
                     },


### PR DESCRIPTION
## 改动

将外观设置里的正文字号滑条从 10% 一档改为 5% 一档，并按 5 的倍数吸附。用户可以选到 105%、115% 等中间字号。

存储仍是整数百分比 `contentFontSize`，正文 Markdown、评论、信息流和公式渲染本来就按百分比缩放，没有改下游。已保存的 100%、110% 等整十值仍然有效。

## 原因

https://github.com/zly2006/zhihu-plus-plus/issues/679 反馈 100% 偏小、110% 偏大。当前滑条范围是 50%–200%、`steps = 14`，步长正好是 10%，这两档相邻。提交者建议的具体档位未当作规格；独立选择最小改动：把步长改成 5%，与同页悬浮按钮透明度设置一致。

Resolves zly2006/zhihu-plus-plus#679

## 影响

- 外观设置 → 阅读 → 字号：可停在 50、55、…、200
- 默认仍是 100%，不改老年模式和其他阅读设置

## 验证

- [x] `assembleLiteDebug` 通过
- [x] `:shared:runKtlintFormatOverCommonMainSourceSet` 通过
- [ ] 本机 Android SDK 没有 emulator 组件，也没有已启动的 AVD，因此没有补设备截图。视觉变化只是滑条刻度更密、说明文字会出现 105% 等值。
